### PR TITLE
Fix utf8 and html5

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::Blosxomについて</title>
 

--- a/about.html
+++ b/about.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::Blosxom�ɂ���</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::Blosxomについて</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,59 +11,59 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">Blosxom</span>�ɂ���</a></h1><p><span class="en">Blosxom</span>�i<span class="en">blossom</span>�Ɣ������܂��B�u���b�T��)�͌y�ʂł���Ȃ���K�v�ȋ@�\��������E�F�u���O�A�v���P�[�V�����ł��B�ȒP�ŁA�g���Ղ��āA���݉^�p����O���ɐ݌v���Ă��܂��B</p>
-<h2>�ȒP</h2><p> �E�F�u���O�A�����āA�S�ẴI�����C���p�u���b�V���O�͂ł��邾���ȒP�ɁA�D���ȃe�L�X�g�G�f�B�^���g���ď����āA�ۑ��ł���ׂ��ł��B<span class="en">Blosxom</span>�ł̓t�@�C���V�X�e���A�t�H���_�A�����ăt�@�C���̓R���e���c�̃f�[�^�x�[�X�Ƃ��ė��p���Ă��܂��B���O�̓v���[���ȃe�L�X�g�t�@�C���ł��B</p>
-<h2>�g���Ղ�</h2><p>���O���쐬�A�ҏW�A���O�ύX�A�폜����ɂ̓R�}���h���C���A<span class="en">FTP</span>�A<span class="en">WebDAV</span>�A���̑��M���̍D���Ȏ�i���g���ăt�@�C���𑀍삵�܂��B�C���|�[�g��G�N�X�|�[�g�ƌ������̂͂���܂���B���O�͂P�s�ڂ��^�C�g���ŁA���̌�S�Ă��{���ɂȂ�ƌ����ȊO�ɂ͉��畡�G�ȍ\���ɂȂ��Ă͂��܂���B</p>
-<h2>���݉^�p��</h2><p> <span class="en">Blosxom</span>�͏����ȃv���O�����ł���ɂ��ւ�炸�A���̃E�F�u���O�A�v���P�[�V������<span class="en">CMS</span>�A�p�u���b�V���V�X�e���ɂ���悤�ȋ@�\������Ă��܂��B<span class="en">Blosxom</span>��<a href="doc_users_plugins.html">�v���O�C���A�[�L�e�N�`��</a>�ɂ����<span class="en">Blosxom</span>�̊j�ƂȂ镔���͌y�ʂ��X�}�[�g�̂܂܂ɁA�قȂ���◘�p���@�ɑ΂���g������񋟂��Ă��܂��B���ۂɂ��̃T�C�g�S�Ă�<span class="en">Blosxom</span>�ō쐬����Ă��܂��B����ɂ��Ă�<a href="colophon.html">���t</a>��ǂ�ŉ������B</p><p><span class="en">Blosxom</span>�͒P���ŗ����ōŏ���<span class="en">Perl</span>�A�v���P�[�V�����ł��邽�߁A�e�ՂɎ���������J�X�^�}�C�Y���鎖���ł���ł��傤�B</p><p>�Ō�ɁA<span class="en">Blosxom</span>�̓I�[�v���\�[�X�ł��B����Ɖ��ς͎��R�ɍs���Ă���č\���܂���B</p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<td id="contents"><h1><a name="top" class="bl"><span class="en">Blosxom</span>について</a></h1><p><span class="en">Blosxom</span>（<span class="en">blossom</span>と発音します。ブロッサム)は軽量でありながら必要な機能を備えたウェブログアプリケーションです。簡単で、使い易くて、相互運用性を念頭に設計しています。</p>
+<h2>簡単</h2><p> ウェブログ、そして、全てのオンラインパブリッシングはできるだけ簡単に、好きなテキストエディタを使って書いて、保存できるべきです。<span class="en">Blosxom</span>ではファイルシステム、フォルダ、そしてファイルはコンテンツのデータベースとして利用しています。ログはプレーンなテキストファイルです。</p>
+<h2>使い易さ</h2><p>ログを作成、編集、名前変更、削除するにはコマンドライン、<span class="en">FTP</span>、<span class="en">WebDAV</span>、その他貴方の好きな手段を使ってファイルを操作します。インポートやエクスポートと言うものはありません。ログは１行目がタイトルで、その後全てが本文になると言う以外には何ら複雑な構成になってはいません。</p>
+<h2>相互運用性</h2><p> <span class="en">Blosxom</span>は小さなプログラムであるにも関わらず、他のウェブログアプリケーションや<span class="en">CMS</span>、パブリッシュシステムにあるような機能を備えています。<span class="en">Blosxom</span>の<a href="doc_users_plugins.html">プラグインアーキテクチャ</a>によって<span class="en">Blosxom</span>の核となる部分は軽量かつスマートのままに、異なる環境や利用方法に対する拡張性を提供しています。実際にこのサイト全てが<span class="en">Blosxom</span>で作成されています。これについては<a href="colophon.html">奥付</a>を読んで下さい。</p><p><span class="en">Blosxom</span>は単純で率直で最小の<span class="en">Perl</span>アプリケーションであるため、容易に実験したりカスタマイズする事ができるでしょう。</p><p>最後に、<span class="en">Blosxom</span>はオープンソースです。入手と改変は自由に行ってくれて構いません。</p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/about.html
+++ b/about.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/colophon.html
+++ b/colophon.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::���t</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::奥付</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,99 +11,99 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">���t</a></h1><p><span class="en">Blosxom.com</span>�T�C�g��<span class="en">Blosxom</span>�ō쐬����Ă��܂��B</p><p>����Ɋւ��āA������b���������Ƃ�����܂�... </p>
-<h2>��</h2><p>����<span class="en">CMS</span>�͍ŐV��<span class="en">Blosxom</span>���g�p���Ă���A�ÓI�y�[�W�i�قƂ�ǂ̃y�[�W�j�Ɠ��I�y�[�W�i���[�U���͂̂��́F�R�����g�A�v���O�C���̓o�^���j��g�ݍ��킹�Ă��܂��B<span class="en">OS</span>��<a href="http://www.freebsd.org/" class="en">FreeBSD</a>�ł��B�T�C�g�� 
---�������-- <a href="http://httpd.apache.org/" class="en">Apache</a>�Œ񋟂��Ă��܂��B�W���I��<a href="http://www.perl.com/" class="en">Perl</a>���g���Ă���i<span class="en">Blosxom</span>��<span class="en">100%</span>�s���A<span class="en">Perl</span>�ŏ�����Ă��܂��j�A���ʂȃ��W���[���̓C���X�g�[�����Ă��܂���B�e�L�X�g�G�f�B�^�͋C���ɂ����<a href="http://www.vim.com/" class="en">vim</a>��<a href="http://www.bbedit.com/" class="en">BBEdit</a>���g�������ăR�[�h�������Ă��܂��B</p>
-<h2>�v���O�C��</h2><p><span class="en">Blosxom</span>�p�̊���̑f���炵���v���O�C��������܂��B�����&quot;�Â���&quot;�̂悤�Ȃ��̂ł��B<span class="en">Blosxom</span>���E�F�u���O�V�X�e���𒴂������̂ɂ��邽�߂ɂ����̃v���O�C���̊�����g���Ă��܂��F</p><dl>
+<td id="contents"><h1><a name="top" class="bl">奥付</a></h1><p><span class="en">Blosxom.com</span>サイトは<span class="en">Blosxom</span>で作成されています。</p><p>これに関して、幾つかお話したいことがあります... </p>
+<h2>環境</h2><p>私の<span class="en">CMS</span>は最新の<span class="en">Blosxom</span>を使用しており、静的ページ（ほとんどのページ）と動的ページ（ユーザ入力のもの：コメント、プラグインの登録等）を組み合わせています。<span class="en">OS</span>は<a href="http://www.freebsd.org/" class="en">FreeBSD</a>です。サイトは 
+--もちろん-- <a href="http://httpd.apache.org/" class="en">Apache</a>で提供しています。標準的な<a href="http://www.perl.com/" class="en">Perl</a>を使っており（<span class="en">Blosxom</span>は<span class="en">100%</span>ピュア<span class="en">Perl</span>で書かれています）、特別なモジュールはインストールしていません。テキストエディタは気分によって<a href="http://www.vim.com/" class="en">vim</a>と<a href="http://www.bbedit.com/" class="en">BBEdit</a>を使い分けてコードを書いています。</p>
+<h2>プラグイン</h2><p><span class="en">Blosxom</span>用の幾つかの素晴らしいプラグインがあります。それは&quot;甘い蜜&quot;のようなものです。<span class="en">Blosxom</span>をウェブログシステムを超えたものにするためにこれらのプラグインの幾つかを使っています：</p><dl>
 <dt class="en">breadcrumbs</dt>
 <dd>
-<p>�y�[�W�̃g�b�v��&quot;�ς񂭂����X�g&quot;��\�����܂��i��@<span class="en">home::colophone</span>�j�B</p>
+<p>ページのトップに&quot;ぱんくずリスト&quot;を表示します（例　<span class="en">home::colophone</span>）。</p>
 </dd>
 <dt class="en">config</dt>
-<dd><p>�T�C�g�S�̂ɐݒ�ƃv���O�C���L�����ɖ����̑g�ݍ��킹��񋟂��܂��B</p></dd>
+<dd><p>サイト全体に設定とプラグイン有効化に無限の組み合わせを提供します。</p></dd>
 <dt class="en">entriescache</dt>
 <dd>
-<p>���ɂ���<span class="en">Blosxom</span>�̃��O�̃C���f�b�N�X����̑��x�����コ���܂��B</p>
+<p>既にある<span class="en">Blosxom</span>のログのインデックス操作の速度を向上させます。</p>
 </dd>
 <dt class="en">file</dt>
-<dd><p>�c�[���o�[��R�����g�t�H�[�����̃R���|�[�l���g��񋟂��܂��B</p></dd>
+<dd><p>ツールバーやコメントフォーム等のコンポーネントを提供します。</p></dd>
 <dt class="en">find</dt>
-<dd><p>���O�̌����@�\��񋟂��܂��B</p></dd>
+<dd><p>ログの検索機能を提供します。</p></dd>
 <dt class="en">interpolate_conditional</dt>
 <dd>
-<p>�󋵂ɂ���Čx����\�������肵�܂��i�� <span class="en">&quot;Be the first to contribute to this page...&quot;</span> 
-����͂��̃y�[�W�ɂ܂��R�����g�������Ƃ��ɕ\������܂��j�B</p>
+<p>状況によって警告を表示したりします（例 <span class="en">&quot;Be the first to contribute to this page...&quot;</span> 
+これはこのページにまだコメントが無いときに表示されます）。</p>
 </dd>
 <dt class="en">meta</dt>
 <dd>
-<p>�e���v���[�g�Ń��^�^�O���g���Ɠ���̃��O�Ƀ^�O�����邱�Ƃ��ł��܂��B�i��@<span class="en">&quot;next...&quot;</span>�@����y�[�W�̉��ɂ������肵�܂��B�����<span class="be">meta-next: 
-someurl</span>�^�O���g���Ă��܂��j�B</p>
+<p>テンプレートでメタタグを使うと特定のログにタグをつけることができます。（例　<span class="en">&quot;next...&quot;</span>　あるページの下にあったりします。これは<span class="be">meta-next: 
+someurl</span>タグを使っています）。</p>
 </dd>
 <dt class="en">postheadprefoot</dt>
-<dd><p>�w�b�_�̌��t�b�^�̑O�ɂ�����Ƃ����ǉ����܂��i<a href="plugin_registry.html">�v���O�C���o�^�y�[�W</a>�̏Љ�Ŏg���Ă��܂��j�B</p></dd>
+<dd><p>ヘッダの後やフッタの前にちょっとだけ追加します（<a href="plugin_registry.html">プラグイン登録ページ</a>の紹介文で使っています）。</p></dd>
 <dt class="en">registory</dt>
-<dd><p>�e���v���[�g�ϐ��Ƀv���O�C���o�^�y�[�W�̋L���̏ڍׂ��W�߂�̂Ɏg���Ă��܂��B</p></dd>
+<dd><p>テンプレート変数にプラグイン登録ページの記事の詳細を集めるのに使っています。</p></dd>
 <dt class="en">sort_by_path</dt>
-<dd><p><a href="plugin_registry.html">�v���O�C���o�^�y�[�W</a>�œ��t�ł͂Ȃ��ăp�X�ŕ��בւ���̂Ɏg���Ă��܂��B</p></dd>
+<dd><p><a href="plugin_registry.html">プラグイン登録ページ</a>で日付ではなくてパスで並べ替えるのに使っています。</p></dd>
 <dt class="en">submission</dt>
-<dd><p>���[�U���y�[�W����v���O�C����o�^����̂Ɏg���Ă��܂��B</p></dd>
+<dd><p>ユーザがページからプラグインを登録するのに使っています。</p></dd>
 <dt class="en">wikieditish</dt>
-<dd><p>�u���E�U�ŃT�C�g��ҏW�ł��܂��B</p></dd>
+<dd><p>ブラウザでサイトを編集できます。</p></dd>
 <dt class="en">wikiwordish</dt>
-<dd><p>�ǂ��ɉ������������v���o���Ȃ��Ă��ǂ��̂ł��B;-)</p></dd>
+<dd><p>どこに何があったか思い出さなくても良いのです。;-)</p></dd>
 <dt class="en">writeback</dt>
-<dd><p>�R�����g�󂯕t���t�H�[���ł��B�y�[�W�̉��Ŏg���Ă��܂��B</p></dd>
+<dd><p>コメント受け付けフォームです。ページの下で使っています。</p></dd>
 </dl>
-<h2>����̗\��</h2><p>�v���O�C���o�^�y�[�W�̂悤�ɊȌ���<span class="en">FAQ</span>��g�p��A�����ċ�������̃\�t�g���Љ�悤�Ɨ\�肵�Ă��܂��B</p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<h2>今後の予定</h2><p>プラグイン登録ページのように簡潔に<span class="en">FAQ</span>や使用例、そして共同制作のソフトを紹介しようと予定しています。</p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/colophon.html
+++ b/colophon.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::奥付</title>
 

--- a/colophon.html
+++ b/colophon.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_dev_overview.html
+++ b/doc_dev_overview.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�J���Ҍ����h�L�������g</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::開発者向けドキュメント</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,56 +11,56 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�J���Ҍ����h�L�������g</a></h1><p>�����C���X�g�[���A���ݒ�A<span class="en">Blosxom</span>�̎g�p���@�Ɋւ���h�L�������g��T���Ă���̂ł���΁A�����ł͂���܂���B<a href="doc_users_overview.html">�Z�p�I��������O�ɒ����ɂ������N���b�N���ĉ������B</a> ;-) </p><p>������<span class="en">Blosxom</span>�̊J���җp�h�L�������g�ł��B<span class="en">Blosxom</span>�J����&quot;����������&quot;�͏��L�҂ŋ������ł�����<span class="en">Rael Dornfest</span>���s���Ă��܂����A�M�����Q���ł���]�n�͏\���Ȃقǂɂ���܂��B</p><p>�܂��̓��[�����O���X�g�ɎQ������<span class="en">Blosxom</span>���[�U�Ɏ��݂��Ă��������B��X�ɂ͑f���炵���A�e���݈Ղ��A�L�p��<span class="en">Blosxom</span>�R�~���j�e�B������܂��B���S�ɓ�����̃R�~���j�e�B�͌��݂ł͌Â����̂ŁA����ɓ������莦����^���鎖�͓���čs���Ă���ނ�Ɠ��l�̖��ɑΖʂ��Ă��܂��B</p><p>���ɁA<span class="en">Blosxom</span>�Ɋւ��ĉ��炩�̃o�O���āA�܂��̓v���O�C���̔��B�Ɋւ��ĉ����������炨�񂹂��������B���[�����O���X�g�ɓ��e���鎖���ł��܂��i�K�؂ȑ薼��t���ĊJ���҂̋C���~�߂�悤�ɂ��ĉ������j�B</p><p>�v���O�C���A�[�L�e�N�`����ʂ���<span class="en">Blosxom</span>�̊g���ⓝ���ɎQ�����ĉ������B<span class="en">Perl</span>�̈����Ɋ���Ă���̂ł���΁A<span class="en">Blosxom</span>�̃v���O�C�����������Ƃ��ł��܂��B�v���O�C���͒P�Ȃ�<span class="en">Perl</span>�X�N���v�g�ł���A<span class="en">Blosxom</span>���A�N�Z�X�\��<span class="en">plugins</span>�f�B���N�g���ɂ���A<span class="en">Blosxom</span>�̎��s���̓���̎��_�ŌĂяo�����T�u���[�`����֐����`�������̂ł��B<a href="doc_dev_plugins.html">�J���Ҍ����̃v���O�C���̊��S�ȃh�L�������g�͂����Ō�����܂��B</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<td id="contents"><h1><a name="top" class="bl">開発者向けドキュメント</a></h1><p>もしインストール、環境設定、<span class="en">Blosxom</span>の使用方法に関するドキュメントを探しているのであれば、ここではありません。<a href="doc_users_overview.html">技術的情報を見る前に直ぐにここをクリックして下さい。</a> ;-) </p><p>ここは<span class="en">Blosxom</span>の開発者用ドキュメントです。<span class="en">Blosxom</span>開発の&quot;美味しい蜜&quot;は所有者で教え役でもある<span class="en">Rael Dornfest</span>が行っていますが、貴方が参加できる余地は十分なほどにあります。</p><p>まずはメーリングリストに参加して<span class="en">Blosxom</span>ユーザに手を貸してください。我々には素晴らしく、親しみ易く、有用な<span class="en">Blosxom</span>コミュニティがあります。完全に入会無しのコミュニティは現在では古いもので、質問に答えたり示唆を与える事は入会して行っている彼らと同様の問題に対面しています。</p><p>次に、<span class="en">Blosxom</span>に関して何らかのバグや提案、またはプラグインの発達に関して何かあったらお寄せください。メーリングリストに投稿する事ができます（適切な題名を付けて開発者の気を止めるようにして下さい）。</p><p>プラグインアーキテクチャを通して<span class="en">Blosxom</span>の拡張や統合に参加して下さい。<span class="en">Perl</span>の扱いに慣れているのであれば、<span class="en">Blosxom</span>のプラグインを書くことができます。プラグインは単なる<span class="en">Perl</span>スクリプトであり、<span class="en">Blosxom</span>がアクセス可能な<span class="en">plugins</span>ディレクトリにあり、<span class="en">Blosxom</span>の実行時の特定の時点で呼び出されるサブルーチンや関数を定義したものです。<a href="doc_dev_plugins.html">開発者向けのプラグインの完全なドキュメントはここで見つかります。</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_dev_overview.html
+++ b/doc_dev_overview.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_dev_overview.html
+++ b/doc_dev_overview.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::開発者向けドキュメント</title>
 

--- a/doc_dev_plugin_register.html
+++ b/doc_dev_plugin_register.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::プラグインの登録</title>
 

--- a/doc_dev_plugin_register.html
+++ b/doc_dev_plugin_register.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_dev_plugin_register.html
+++ b/doc_dev_plugin_register.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,“ú–{Œê,–|–ó">
-<title>blosxomƒTƒCƒg‚Ì“ú–{Œê–ó::ƒvƒ‰ƒOƒCƒ“‚Ì“o˜^</title>
+<meta name="keywords" content="blosxom,æ—¥æœ¬èªž,ç¿»è¨³">
+<title>blosxomã‚µã‚¤ãƒˆã®æ—¥æœ¬èªžè¨³::ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç™»éŒ²</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,69 +11,69 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::“ú–{Œê–ó</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="ƒtƒŒ[ƒ€">
+<div id="header"><span class="en">blosxom</span>::æ—¥æœ¬èªžè¨³</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="ãƒ•ãƒ¬ãƒ¼ãƒ ">
 <tbody>
 <tr>
 <td id="menu">
-<h4>–|–ó‚É‚Â‚¢‚Ä</h4>
+<h4>ç¿»è¨³ã«ã¤ã„ã¦</h4>
 <ul class="mid">
-<li><a href="index.html" title="‚¨“Ç‚Ý‚­‚¾‚³‚¢">‚¨“Ç‚Ý‚­‚¾‚³‚¢</a></li>
+<li><a href="index.html" title="ãŠèª­ã¿ãã ã•ã„">ãŠèª­ã¿ãã ã•ã„</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom‚É‚Â‚¢‚Ä"><span class="en">Blosxom</span>‚É‚Â‚¢‚Ä</a></li>
-<li><a href="features.html" title="Blosxom‚Ì‹@”\">‹@”\</a></li>
-<li><a href="colophon.html" title="‰œ•t">‰œ•t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ƒjƒ…[ƒX">ƒjƒ…[ƒXi‰pŒêj</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="ƒ[ƒŠƒ“ƒOƒŠƒXƒg">ƒ[ƒŠƒ“ƒOƒŠƒXƒgi‰pŒêj</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="Šñ‘¡">Šñ‘¡i‰pŒêj</a></li>
+<li><a href="about.html" title="Blosxomã«ã¤ã„ã¦"><span class="en">Blosxom</span>ã«ã¤ã„ã¦</a></li>
+<li><a href="features.html" title="Blosxomã®æ©Ÿèƒ½">æ©Ÿèƒ½</a></li>
+<li><a href="colophon.html" title="å¥¥ä»˜">å¥¥ä»˜</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ãƒ‹ãƒ¥ãƒ¼ã‚¹">ãƒ‹ãƒ¥ãƒ¼ã‚¹ï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆ">ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="å¯„è´ˆ">å¯„è´ˆï¼ˆè‹±èªžï¼‰</a></li>
 </ul>
-<h4>ƒ†[ƒUŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>ãƒ¦ãƒ¼ã‚¶å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom‚ÌŠT—v">ŠT—v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom‚ÌƒCƒ“ƒXƒg[ƒ‹">ƒCƒ“ƒXƒg[ƒ‹</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom‚ÌÝ’è">ŠÂ‹«Ý’è</a></li>
-<li><a href="doc_users_blog.html" title="ƒEƒFƒuƒƒO">ƒEƒFƒuƒƒO</a></li>
-<li><a href="doc_users_view.html" title="ƒEƒFƒuƒƒO‚Ì‰{——">‰{——</a></li>
-<li><a href="doc_users_flavour.html" title="ƒtƒŒ[ƒo[">ƒtƒŒ[ƒo[</a></li>
-<li><a href="doc_users_syndicate.html" title="ƒVƒ“ƒWƒP[ƒg">ƒVƒ“ƒWƒP[ƒg</a></li>
-<li><a href="doc_users_plugins.html" title="ƒvƒ‰ƒOƒCƒ“">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="plugin_registry.html" title="ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW">ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW</a></li>
-<li><a href="doc_users_configure_static.html" title="Ã“I•\Ž¦‚ÌÝ’è">Ã“I•\Ž¦‚ÌÝ’è</a></li>
-<li><a href="faq.html" title="—Ç‚­‚ ‚éŽ¿–â"><span class="en">faq</span></a></li>
-<li>Žg—p—á*</li>
+<li><a href="doc_users_overview.html" title="Blosxomã®æ¦‚è¦">æ¦‚è¦</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomã®ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«">ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomã®è¨­å®š">ç’°å¢ƒè¨­å®š</a></li>
+<li><a href="doc_users_blog.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°">ã‚¦ã‚§ãƒ–ãƒ­ã‚°</a></li>
+<li><a href="doc_users_view.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°ã®é–²è¦§">é–²è¦§</a></li>
+<li><a href="doc_users_flavour.html" title="ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼">ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼</a></li>
+<li><a href="doc_users_syndicate.html" title="ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ">ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ</a></li>
+<li><a href="doc_users_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="plugin_registry.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸</a></li>
+<li><a href="doc_users_configure_static.html" title="é™çš„è¡¨ç¤ºã®è¨­å®š">é™çš„è¡¨ç¤ºã®è¨­å®š</a></li>
+<li><a href="faq.html" title="è‰¯ãã‚ã‚‹è³ªå•"><span class="en">faq</span></a></li>
+<li>ä½¿ç”¨ä¾‹*</li>
 </ul>
-<h4>ŠJ”­ŽÒŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>é–‹ç™ºè€…å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="ŠT—vFŠJ”­ŽÒŒü‚¯">ŠT—v</a></li>
-<li><a href="doc_dev_plugins.html" title="ƒvƒ‰ƒOƒCƒ“FŠJ”­ŽÒŒü‚¯">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="doc_dev_plugin_register.html" title="ŠJ”­ŽÒŒü‚¯Fƒvƒ‰ƒOƒCƒ““o˜^">ƒvƒ‰ƒOƒCƒ“‚Ì“o˜^</a></li>
+<li><a href="doc_dev_overview.html" title="æ¦‚è¦ï¼šé–‹ç™ºè€…å‘ã‘">æ¦‚è¦</a></li>
+<li><a href="doc_dev_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ï¼šé–‹ç™ºè€…å‘ã‘">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="doc_dev_plugin_register.html" title="é–‹ç™ºè€…å‘ã‘ï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç™»éŒ²</a></li>
 </ul>
-<h4>ƒ_ƒEƒ“ƒ[ƒh</h4>
+<h4>ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="‘S‚Ä‚Ìl‚Ö">‘S‚Ä‚Ìl‚Ö</a></li>
-<li><a href="license.html" title="ƒ‰ƒCƒZƒ“ƒX">ƒ‰ƒCƒZƒ“ƒX</a></li>
-<li>‹¤“¯§ì*</li>
+<li><a href="downloads.html" title="å…¨ã¦ã®äººã¸">å…¨ã¦ã®äººã¸</a></li>
+<li><a href="license.html" title="ãƒ©ã‚¤ã‚»ãƒ³ã‚¹">ãƒ©ã‚¤ã‚»ãƒ³ã‚¹</a></li>
+<li>å…±åŒåˆ¶ä½œ*</li>
 </ul>
-<p>*ŒöŽ®ƒTƒCƒg‚Å–¢Ž·•M</p>
+<p>*å…¬å¼ã‚µã‚¤ãƒˆã§æœªåŸ·ç­†</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">ƒvƒ‰ƒOƒCƒ“‚Ì“o˜^</a></h1><p>ƒRƒ~ƒ…ƒjƒeƒB‚Æ‹¤—L‚Å‚«‚é<span class="en">Blosxom</span>ƒvƒ‰ƒOƒCƒ“‚ð‚¨Ž‚¿‚Å‚·‚©H@‚±‚±‚Åƒvƒ‰ƒO‚ð‘}‚µ‚Ä‰º‚³‚¢I@‚¿‚å‚Á‚ÆŒ©‚Ä‚©‚çƒfƒBƒŒƒNƒgƒŠ‚É’Ç‰Á‚µ‚Ü‚·B</p><p><a href="http://www.blosxom.com/documentation/developers/plugin_register.html">ŽÀÛ‚Ì“o˜^êŠ‚Í‚±‚±‚Å‚·</a></p><p>“o˜^Žž‚É“ü—Í‚·‚é€–ÚF</p><ul class="mid">
-<li>ƒvƒ‰ƒOƒCƒ“–¼</li>
-<li>à–¾</li>
-<li>ƒvƒ‰ƒOƒCƒ“‚ð’u‚¢‚Ä‚ ‚é<span class="en">URL</span></li>
-<li>ìŽÒ–¼</li>
-<li>ìŽÒ‚Ì<span class="en">URL</span></li>
-<li>ŠÂ‹«<br>
-ƒhƒ‰ƒbƒO•ƒhƒƒbƒvG@Ý’è‚Ì•K—v‚È‚µ<br>
-Ý’è‰Â”\G
-Šô‚Â‚©‚ÌƒIƒvƒVƒ‡ƒ“‚ÌÝ’è€–Ú‚ ‚è<br>
-Ý’è•K{G@Šô‚Â‚©Ý’è‚ª•K—v‚È€–Ú‚ ‚è<br>
+<td id="contents"><h1><a name="top" class="bl">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç™»éŒ²</a></h1><p>ã‚³ãƒŸãƒ¥ãƒ‹ãƒ†ã‚£ã¨å…±æœ‰ã§ãã‚‹<span class="en">Blosxom</span>ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ãŠæŒã¡ã§ã™ã‹ï¼Ÿã€€ã“ã“ã§ãƒ—ãƒ©ã‚°ã‚’æŒ¿ã—ã¦ä¸‹ã•ã„ï¼ã€€ã¡ã‚‡ã£ã¨è¦‹ã¦ã‹ã‚‰ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã«è¿½åŠ ã—ã¾ã™ã€‚</p><p><a href="http://www.blosxom.com/documentation/developers/plugin_register.html">å®Ÿéš›ã®ç™»éŒ²å ´æ‰€ã¯ã“ã“ã§ã™</a></p><p>ç™»éŒ²æ™‚ã«å…¥åŠ›ã™ã‚‹é …ç›®ï¼š</p><ul class="mid">
+<li>ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å</li>
+<li>èª¬æ˜Ž</li>
+<li>ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ç½®ã„ã¦ã‚ã‚‹<span class="en">URL</span></li>
+<li>ä½œè€…å</li>
+<li>ä½œè€…ã®<span class="en">URL</span></li>
+<li>ç’°å¢ƒ<br>
+ãƒ‰ãƒ©ãƒƒã‚°ï¼†ãƒ‰ãƒ­ãƒƒãƒ—ï¼›ã€€è¨­å®šã®å¿…è¦ãªã—<br>
+è¨­å®šå¯èƒ½ï¼›
+å¹¾ã¤ã‹ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®è¨­å®šé …ç›®ã‚ã‚Š<br>
+è¨­å®šå¿…é ˆï¼›ã€€å¹¾ã¤ã‹è¨­å®šãŒå¿…è¦ãªé …ç›®ã‚ã‚Š<br>
 </li>
-<li>”õl</li>
-</ul><p class="nextLink"><a href="#top">[ƒy[ƒW‚Ìæ“ª‚Ö–ß‚é]</a></p></td>
+<li>å‚™è€ƒ</li>
+</ul><p class="nextLink"><a href="#top">[ãƒšãƒ¼ã‚¸ã®å…ˆé ­ã¸æˆ»ã‚‹]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_dev_plugins.html
+++ b/doc_dev_plugins.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�J���Ҍ��� - �v���O�C��</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::開発者向け - プラグイン</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,57 +11,57 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�v���O�C��</a></h1><p><span class="en">Blosxom</span>�̃v���O�C���A�[�L�e�N�`���ɂ����<span class="en">Blosxom</span>�̊j�ƂȂ镔���͌y�ʂ��X�}�[�g�̂܂܂ɁA�قȂ���◘�p���@�ɑ΂���g������񋟂��Ă��܂��B</p><h2>�v���O�C��</h2><h3>�v���O�C���o�^�y�[�W...</h3><p><a href="plugin_registry.html">�v���O�C���̓o�^�y�[�W</a>�����ĕK�v�ȃv���O�C����T���ĉ������B</p><p>�����ɂ͂��傤�ǋM���̂悤��<span class="en">Blosxom</span>���[�U���J�������v���O�C�������X�g�A�b�v�����Ă���A�����𑱂��Ă��܂��B�����ł̓v���O�C�����񂳂�Ă��āA�v���O�C���ɂ��ẴR�����g��ǂ񂾂肵����A���ɂ��ǉ��e���v���[�g���������肵�܂��B�摜�v���O�C���͉摜�Q�Ƃ���T�C�Y�ύX�܂őS�Ă�񋟂��Ă��܂��̂ŃM�������[���\�z���鎖���ł��܂��B���͌n�̃v���O�C���͕ԐM�i�R�����g�ƃg���b�N�o�b�N�j�A���ʊ֌W�̒ǐՁA���[�����E�F�u���O�ɂ���ƌ������@�\��񋟂��Ă��܂��B</p><p>�R�~���j�e�B�Ƌ��L�ł���v���O�C�����������ł���?�@<a href="doc_dev_plugin_register.html">�����Ńv���O�������Ă��������I</a></p><h2>�v���O�C���Ƃ́H</h2><p><span class="en">Perl</span>��������x�m���Ă����<span class="en">Blosxom</span>�̃v���O�C�������������ł��܂��B�v���O�C���͒P����<span class="en">Perl</span>�X�N���v�g�ŁA<span class="en">Blosxom</span>���A�N�Z�X���邱�Ƃ̂ł���<span class="be">plugins</span>�f�B���N�g���ɒu���A<span class="en">Blosxom</span>�̎��s���ɓ���̈ʒu�ŌĂяo�����T�u���[�`����֐����`���܂��B</p><h3>�v���O�C�����g��...</h3><p><a href="doc_users_overview.html">���[�U�����̃v���O�C���h�L�������g</a>�Ńv���O�C���T�|�[�g�̗L�����A�v���O�C���̃C���X�g�[���A�v���O�C���̎��s���Ԃ̕ύX�A�v���O�C���̍폜���𗝉����ĉ������B</p><h3>
-<span class="be">Plugin</span>�̐S...</h3><p>�������A�M���̍D���Ȃ悤�ɂ���΂悢�̂ł����A����<span class="en">Blosxom</span>�̃v���O�C���͒N�������̗͂̃R���r�l�[�V�����ƊȒP�g�p���\���Ɋ������A������<span class="en">Blosxom</span>�̍��������ė~�����Ɩ]�ނ̂ł��B�ǂ����ł��邾���ȒP�ɃC���X�g�[���ł��A�ݒ�ł��A�����ē���ł���悤�A�S�����ĉ������B</p><p>���z�I�ɂ́A�v���O�C���Ƃ�<strong class="se">plugins</strong>�f�B���N�g���Ƀh���b�v�ł���P��t�@�C���ł���A�I�v�V�����Ŋ���ݒ�ł�����̂ł��B</p><p>�����ǉ�����K�v����������A���̃��W���[����K�v�Ƃ���ꍇ�ɂ̓v���O�C���Ƃ��Ă����S�Ă�񋟂��A<strong class="se">plugins</strong>�t�H���_�Ɉ�܂Ƃ߂ɂ��ăh���b�v�ł���悤�ɃT�u�f�B���N�g���ɂ܂Ƃ߂�悤�ɂ��ĉ������B���[�U�����ƂɂȂ�����R���p�C��������<span class="en">Perl</span>���W���[�����C���X�g�[�����Ȃ��Ă͂Ȃ�Ȃ��ȂǁA�ߓx�ȏ�����K�v�Ƃ��Ȃ��悤�ɂ��ĉ������B</p><p>�܂��A��ɃN���X�v���b�g�t�H�[���̖���O���ɂ����Ă��������B<span class="en">Blosxom</span>�͂ǂ��ł����삷��B�����쐬�����S�Ẵ��W���[���������ł���悤�ɁB���͉��������Z�N�V�[���Ɍ�������̂��ǂ��ł������ɓ��삷������<span class="en">Linux</span>�ł̂ݓ��삷�鉽���Z�N�V�[�Ȃ��̂��쐬����̂͒p���������v���Ă��܂��B</p><h3>�v���O�C��������...</h3><p><span class="en">Blosxom</span>�̃v���O�C���A�[�N�e�N�`���𗝉�����ł��ǂ����@�́A���ԂɊe���ڂ�i��ł������Ƃł��B</p><h3>...<span class="be">Blosxom</span>�ϐ�</h3><p>�e�v���O�C���ŉ\�Ȃ��Ƃ́A�L�[�ƂȂ�<span class="en">Blosxom</span>�̕ϐ��i�ǂݍ��݁F�ʗ�ł͓ǂݍ��ݐ�p�j���Q�Ƃ��鎖�ł��B���̑啔����<span class="en">Blosxom</span>��<span class="be">#--- Configurable varibles ---</span>�Z�N�V�����Ɍ����A<a href="doc_users_configure.html">�ݒ�h�L�������g</a>���Ő�������Ă��܂��B�ȉ��͊��S�ȕϐ����X�g�ł��F</p><ul class="mid">
+<td id="contents"><h1><a name="top" class="bl">プラグイン</a></h1><p><span class="en">Blosxom</span>のプラグインアーキテクチャによって<span class="en">Blosxom</span>の核となる部分は軽量かつスマートのままに、異なる環境や利用方法に対する拡張性を提供しています。</p><h2>プラグイン</h2><h3>プラグイン登録ページ...</h3><p><a href="plugin_registry.html">プラグインの登録ページ</a>を見て必要なプラグインを探して下さい。</p><p>そこにはちょうど貴方のような<span class="en">Blosxom</span>ユーザが開発したプラグインがリストアップさえており、成長を続けています。そこではプラグインが陳列されていて、プラグインについてのコメントを読んだりしたり、他にも追加テンプレートがあったりします。画像プラグインは画像参照からサイズ変更まで全てを提供していますのでギャラリーを構築する事ができます。入力系のプラグインは返信（コメントとトラックバック）、因果関係の追跡、メールをウェブログにすると言った機能を提供しています。</p><p>コミュニティと共有できるプラグインをお持ちですか?　<a href="doc_dev_plugin_register.html">ここでプラグを差してください！</a></p><h2>プラグインとは？</h2><p><span class="en">Perl</span>をある程度知っていれば<span class="en">Blosxom</span>のプラグインを書く事ができます。プラグインは単純な<span class="en">Perl</span>スクリプトで、<span class="en">Blosxom</span>がアクセスすることのできる<span class="be">plugins</span>ディレクトリに置き、<span class="en">Blosxom</span>の実行時に特定の位置で呼び出されるサブルーチンや関数を定義します。</p><h3>プラグインを使う...</h3><p><a href="doc_users_overview.html">ユーザ向けのプラグインドキュメント</a>でプラグインサポートの有効化、プラグインのインストール、プラグインの実行順番の変更、プラグインの削除等を理解して下さい。</p><h3>
+<span class="be">Plugin</span>の心...</h3><p>もちろん、貴方の好きなようにすればよいのですが、私は<span class="en">Blosxom</span>のプラグインは誰もがその力のコンビネーションと簡単使用を十分に感じ取れ、そして<span class="en">Blosxom</span>の魂を感じて欲しいと望むのです。どうぞできるだけ簡単にインストールでき、設定でき、そして動作できるよう、心がけて下さい。</p><p>理想的には、プラグインとは<strong class="se">plugins</strong>ディレクトリにドロップできる単一ファイルであり、オプションで環境を設定できるものです。</p><p>何か追加する必要があったり、他のモジュールを必要とする場合にはプラグインとしてそれら全てを提供し、<strong class="se">plugins</strong>フォルダに一まとめにしてドロップできるようにサブディレクトリにまとめるようにして下さい。ユーザが専門家になったりコンパイルしたり<span class="en">Perl</span>モジュールをインストールしなくてはならないなど、過度な条件を必要としないようにして下さい。</p><p>また、常にクロスプラットフォームの問題を念頭においてください。<span class="en">Blosxom</span>はどこでも動作する。私が作成した全てのモジュールがそうであるように。私は何か少しセクシーさに欠けるものがどこでも快調に動作する一方で<span class="en">Linux</span>でのみ動作する何かセクシーなものを作成するのは恥ずかしく思っています。</p><h3>プラグインを書く...</h3><p><span class="en">Blosxom</span>のプラグインアークテクチャを理解する最も良い方法は、順番に各項目を進んでいくことです。</p><h3>...<span class="be">Blosxom</span>変数</h3><p>各プラグインで可能なことは、キーとなる<span class="en">Blosxom</span>の変数（読み込み：通例では読み込み専用）を参照する事です。その大部分は<span class="en">Blosxom</span>の<span class="be">#--- Configurable varibles ---</span>セクションに現われ、<a href="doc_users_configure.html">設定ドキュメント</a>内で説明されています。以下は完全な変数リストです：</p><ul class="mid">
 <li class="en">$blog_title</li>
 <li class="en">
 $blog_description</li>
@@ -101,25 +101,25 @@ $static_or_dynamic</li>
 $output</li>
 <li class="en">
 $version </li>
-</ul><p> �����̕ϐ��̑S�Ă̓��C����<span class="be">Blosxom</span>�̖��O��ԂŎg���܂��B<span class="be">$blosxom::datadir</span>�A<span class="be">@blosxom::plugin</span>�̂悤�ɂ��ĎQ�Ƃ��܂��B</p><p>�e�T�u���[�`���ɓK�؂ɓn���ꂽ�ϐ��͎Q�ƂƕύX�̂��߂ɃR���e�L�X�g�ɌŗL�Ȃ��̂ł��i��@�b��̖{���̎Q�Ƃ�<span class="be">story()</span>�T�u���[�`���ɓn����܂��j�B</p><h3>...�ǂ��X�^�[�g��؂�</h3><p>�S�Ẵv���O�C���̓v���O�C���̎��ʂŎn�܂鎖�ɂȂ��Ă��܂��B����̃R�����g���t��������̍s�Ŏn�܂�̂��ǂ����@�ł�...</p><pre class="en">
+</ul><p> これらの変数の全てはメインの<span class="be">Blosxom</span>の名前空間で使えます。<span class="be">$blosxom::datadir</span>、<span class="be">@blosxom::plugin</span>のようにして参照します。</p><p>各サブルーチンに適切に渡された変数は参照と変更のためにコンテキストに固有なものです（例　話題の本文の参照は<span class="be">story()</span>サブルーチンに渡されます）。</p><h3>...良いスタートを切る</h3><p>全てのプラグインはプラグインの識別で始まる事になっています。幾つかのコメントが付いた慣例の行で始まるのが良い方法です...</p><pre class="en">
 # Blosxom Plugin: sample
 # Author(s): Rael Dornfest  
 # Version: 0+1i
 # Blosxom Home/Docs/Licensing: http://www.raelity.org/apps/blosxom/
-</pre><p>�M���̃v���O�C���͂��̃v���O�C���̖��O��Ԃő��삷��悤�ɂ��āA���̃v���O�C���ƑS�Ă̕ϐ��ƃT�u���[�`�����������Ȃ��悤�ɂ��ׂ��ł��BPerl�ł�<span class="be">package</span>�ł�����s���܂��F</p><pre class="en">package sample;</pre><p>���̗�ł́A<span class="be">sample</span>�ƌ������O�̃p�b�P�[�W�ɂȂ�܂��B</p><p>�e�v���O�C���͂��ꎩ�g�̃p�b�P�[�W�œ��삷�邾���łȂ��A���ꎩ�g�̃t�@�C���ɒu���܂��B�t�@�C����<strong class="se">plugins</strong>�f�B���N�g���ɒu���悤�ɂ��A�t�@�C�����̓p�b�P�[�W���ƌ����ɓ������O�ɂ��Ȃ��Ă͂Ȃ�܂���B���̂��߁A���̗�ł̓v���O�C����<strong class="se">plugins/sample</strong>�ƂȂ�܂��B</p><p>�v���O�C�����ǂݍ��܂�鏇�Ԃ��R���g���[���������̂ł���΁A�t�@�C���������̂悤�ɂ��܂��F<span class="be">00loadfirst</span>�A<span class="be">50loadsomtime</span>�A<span class="be">99loadlast</span>���B�v���O�C���̓A���t�@�x�b�g���œǂݍ��܂��̂ł��̂悤�ɂ���Ə��Ԃ������I�ɕύX���鎖���ł��܂��B<span class="en">Blosxom</span>�̓v���O�C�������琔�������O���̂Ńp�b�P�[�W���Ńv���O�C�����Q�Ƃł��܂��i�� <span class="be">loadfirst</span>�j�B</p><h3>...���ݒ�A�ϐ��A���W���[��</h3><p>��������͋M����<span class="en">Perl</span>�͎��R�ɓ��삵�܂��B�ȉ��͗����A�g�p�A�M���ւ̃v���O�C���ւ̓K�p�ɂ��Ă̎��̒�Ăł��B</p><p><span class="en">Blosxom</span>���ꎩ�̂ł̓��[�U���ύX�ł���ϐ��͈ꏏ�ɂ܂Ƃ߂�ׂ��ł��B�t�@�C���̐擪������ݒ�ϐ������̑S�Ă̓��[�U�ւ̏��ƕύX���Ӑ}�������̂ɂ��邱�Ƃ��Ă��܂��B�ȉ��̂悤�Ȋ����ł��F</p><pre class="en">
+</pre><p>貴方のプラグインはそのプラグインの名前空間で操作するようにして、他のプラグインと全ての変数とサブルーチンが競合しないようにすべきです。Perlでは<span class="be">package</span>でこれを行います：</p><pre class="en">package sample;</pre><p>この例では、<span class="be">sample</span>と言う名前のパッケージになります。</p><p>各プラグインはそれ自身のパッケージで動作するだけでなく、それ自身のファイルに置きます。ファイルは<strong class="se">plugins</strong>ディレクトリに置くようにし、ファイル名はパッケージ名と厳密に同じ名前にしなくてはなりません。そのため、この例ではプラグインは<strong class="se">plugins/sample</strong>となります。</p><p>プラグインが読み込まれる順番をコントロールしたいのであれば、ファイル名を次のようにします：<span class="be">00loadfirst</span>、<span class="be">50loadsomtime</span>、<span class="be">99loadlast</span>等。プラグインはアルファベット順で読み込まれるのでこのようにすると順番を強制的に変更する事ができます。<span class="en">Blosxom</span>はプラグイン名から数字を取り外すのでパッケージ名でプラグインを参照できます（例 <span class="be">loadfirst</span>）。</p><h3>...環境設定、変数、モジュール</h3><p>ここからは貴方の<span class="en">Perl</span>は自由に動作します。以下は理解、使用、貴方へのプラグインへの適用についての私の提案です。</p><p><span class="en">Blosxom</span>それ自体ではユーザが変更できる変数は一緒にまとめるべきです。ファイルの先頭から環境設定変数部分の全てはユーザへの情報と変更を意図したものにすることを提案します。以下のような感じです：</p><pre class="en">
 # --- Configration Variables -----
 $email_address = 'me@example';
 # --------------------------------
-</pre><p>���ݒ�ϐ��̓��[�U���v���O�C����K�؂Ɏg����悤�ɂ��邽�߂ɕK�v�Ȃ��̂ɂ��ׂ��ł��B</p><p>�v���O�C���ɕ֗��ȕϐ����`���鎞�Ԃł��F</p><pre class="en">$title_and_path = '';
-$story_number = 1;</pre><p>�M������`���������̕ϐ��̑S�Ă̓t���[�o�[�e���v���[�g�Ŏg�p�ł��܂��B����ɂ͖��O��Ԃ�t������<span class="be">$title_and_path</span>�̓e���v���[�g���œT�^�I��<span class="en">Perl</span>�X�^�C����<span class="be">$sample::title_and_path</span>�ŎQ�Ƃ���܂��B</p><p>���ۂ̂Ƃ���A�v���O�C���A�[�L�e�N�`���̎g�p��<span class="en">Blosxom</span>�{�̂ɖ����ϐ����M�����P�ɒ�`���邱�Ƃł��B</p><p>�M���̃v���O�C���ɕK�v��<span class="en">Perl</span>���W���[����K�v�Ƃ���ɂ͈ȉ��̂悤�ɂ��܂��B�����������<span class="en">CGI</span>���W���[���̑f���炵���֐��ɃA�N�Z�X����K�v�����邩������܂���F</p><pre class="en">use CGI qw/:standard/; </pre><h3>...�T�u���[�`��</h3><p><span class="en">Blosxom</span>�̃v���O�C���A�[�L�e�N�`���͈�A�̃t�b�N���`���܂��B����͊e�v���O�C�������삷��@���^����<span class="en">Blosxom</span>�̎��s���̏ꏊ�ł��B�����̃t�b�N�� --�P�ɃT�u���[�`���ł�-- �͎��s�̏��Ԃ�����܂��F<span class="be">start, entries, filter, head, sort, date, story, foot, end</span>�B�B��K�v�ȃT�u���[�`����<span class="en">start</span>�ł��B</p><h3>...�T�u���[�`�� ...<span class="en">start</span></h3><p><span class="en">start</span>�T�u���[�`�����K�v�ł��B����̖ړI�͓ǂݍ��ރv���O�C��������A�����Ă�����L���ɂ���悤�ɂ���Ƃ�������<span class="en">Blosxom</span>�ɒm�点�邱�Ƃł��B  <span class="en">Blosxom</span>�̗��V�ł͂����1�i<span class="en">true</span>�j��Ԃ����Ƃōs���܂��B�ȉ��͍ł��ȒP�ȗ�ł��F</p><pre class="en">
+</pre><p>環境設定変数はユーザがプラグインを適切に使えるようにするために必要なものにすべきです。</p><p>プラグインに便利な変数を定義する時間です：</p><pre class="en">$title_and_path = '';
+$story_number = 1;</pre><p>貴方が定義したこれらの変数の全てはフレーバーテンプレートで使用できます。それには名前空間を付加して<span class="be">$title_and_path</span>はテンプレート内で典型的な<span class="en">Perl</span>スタイルの<span class="be">$sample::title_and_path</span>で参照されます。</p><p>実際のところ、プラグインアーキテクチャの使用は<span class="en">Blosxom</span>本体に無い変数を貴方が単に定義することです。</p><p>貴方のプラグインに必要な<span class="en">Perl</span>モジュールを必要とするには以下のようにします。もしかすると<span class="en">CGI</span>モジュールの素晴らしい関数にアクセスする必要があるかもしれません：</p><pre class="en">use CGI qw/:standard/; </pre><h3>...サブルーチン</h3><p><span class="en">Blosxom</span>のプラグインアーキテクチャは一連のフックを定義します。これは各プラグインが動作する機会を与える<span class="en">Blosxom</span>の実行内の場所です。これらのフックは --単にサブルーチンです-- は実行の順番があります：<span class="be">start, entries, filter, head, sort, date, story, foot, end</span>。唯一必要なサブルーチンは<span class="en">start</span>です。</p><h3>...サブルーチン ...<span class="en">start</span></h3><p><span class="en">start</span>サブルーチンが必要です。これの目的は読み込むプラグインがあり、そしてそれらを有効にするようにするという事を<span class="en">Blosxom</span>に知らせることです。  <span class="en">Blosxom</span>の流儀ではそれを1（<span class="en">true</span>）を返すことで行います。以下は最も簡単な例です：</p><pre class="en">
 sub start {
    1;
 }
-</pre><p>�����<span class="en">Blosxom</span>�Ƀv���O�C���������Ă��Ċe�R�[���o�b�N�n�_�Ńv���O�C�����U������悤�ɂƌ�������<span class="en">Blosxom</span>�ɒm�点�܂��B</p><p><span class="en">start</span>���[�`���͓��I�A�܂��͐ÓI�\���Ƀv���O�C���̑���𐧌����銮�S�Ȉʒu�ł��F</p><pre class="en">
+</pre><p>これは<span class="en">Blosxom</span>にプラグインが生きていて各コールバック地点でプラグインが振舞えるようにと言う事を<span class="en">Blosxom</span>に知らせます。</p><p><span class="en">start</span>ルーチンは動的、または静的表示にプラグインの操作を制限する完全な位置です：</p><pre class="en">
 sub start {
    return $blosxom::static_or_dynamic eq 'dynamic' ? 1 : 0;
 }
-</pre><p>��L��ł�<span class="en">Blosxom</span>�����ݓ��I�ɓ��삵�Ă���ꍇ�ɂ̂݃v���O�C�������삷��悤�ɂ��Ă��܂��B�����łȂ��ꍇ�ɂ̓v���O�C���̓�����~�����܂��B</p><h3>...�T�u���[�`�� ...<span class="be">template</span></h3><p> <span class="be">template</span>�T�u���[�`���̓v���O�C���ɕW����<span class="en">template</span>�T�u���[�`����u��������@���^���܂��i��͋M���̃e���v���[�g��񋟂�����̂ł��j�B</p><p><span class="be">template</span>�t�b�N�͕W���i<span class="en">Blosxom</span>�{�̂�<span class="be">$template</span>�Œ�`���ꊄ�蓖�Ă��Ă���j�̏ꏊ�Ŏg���铽���֐��ւ̎Q�Ƃ�Ԃ��Ȃ��Ă͂Ȃ�܂���B</p><p>�p�X�A�e���v���[�g�A�`�����N�i�� <span class="en">&quot;head&quot;</span>��<span class="en">&quot;foot&quot;</span>�j�����ăt���[�o�[��^���܂��B�T�u���[�`���̓e���v���[�g�R���|�[�l���g�̃R���e���c��Ԃ��Ȃ��Ă͂Ȃ�܂���B</p><p>�ȉ��̗�ł̓��C���̃f�[�^�f�B���N�g���ł͂Ȃ��đ����<span class="be">&quot;flavour&quot;</span>�f�B���N�g������e���v���[�g��ǂݍ��݂܂��B�E�F�u���O�L������̓t���[�o�[��؂藣���Ă��܂��F</p><pre class="en">
+</pre><p>上記例では<span class="en">Blosxom</span>が現在動的に動作している場合にのみプラグインが動作するようにしています。そうでない場合にはプラグインの動作を停止させます。</p><h3>...サブルーチン ...<span class="be">template</span></h3><p> <span class="be">template</span>サブルーチンはプラグインに標準の<span class="en">template</span>サブルーチンを置き換える機会を与えます（一つは貴方のテンプレートを提供するものです）。</p><p><span class="be">template</span>フックは標準（<span class="en">Blosxom</span>本体で<span class="be">$template</span>で定義され割り当てられている）の場所で使われる匿名関数への参照を返さなくてはなりません。</p><p>パス、テンプレート、チャンク（例 <span class="en">&quot;head&quot;</span>や<span class="en">&quot;foot&quot;</span>）そしてフレーバーを与えます。サブルーチンはテンプレートコンポーネントのコンテンツを返さなくてはなりません。</p><p>以下の例ではメインのデータディレクトリではなくて代わりの<span class="be">&quot;flavour&quot;</span>ディレクトリからテンプレートを読み込みます。ウェブログ記事からはフレーバーを切り離しています：</p><pre class="en">
 sub template {
    return sub {
      my ($path, $chunk, $flavour) = @_;
@@ -135,12 +135,12 @@ sub template {
                       || '');
    };
  }
-</pre><p>�M���̃v���O�C�����f�t�H���g�̂��̂��㏑�����Ȃ��悤�ɂ���ꍇ�͒P�ɖ���`�̒l��Ԃ����悤�ɂ��܂��F</p><pre class="en">
+</pre><p>貴方のプラグインがデフォルトのものを上書きしないようにする場合は単に未定義の値を返しすようにします：</p><pre class="en">
 sub template {
   # 
   return undef;
 }
-</pre><p>���̂悤�ɂ���ƌ㑱�̃v���O�C���͕W����<span class="en">template</span>�T�u���[�`�����㏑������@���^�����܂��B</p><h3>...�T�u���[�`�� ...<span class="be">entries</span></h3><p><span class="be">entries</span>�T�u���[�`���̓f�t�H���g�̋L�������T�u���[�`���i�M���̑S�ẴE�F�u���O�L����������j��u��������@���񋟂��܂��B</p><p> <span class="be">entries</span>�t�b�N��<span class="en">Blosxom</span>�{�̂�<span class="en">$entries</span>�Ƃ��Ē�`����Ă�W���̂��̂����������֐��ւ̎Q�Ƃ�Ԃ��Ȃ��Ă͂Ȃ�܂���B</p><p>�T�u���[�`���̓t�@�C���̃n�b�V���Ƒ��̃C���f�b�N�X�i�ÓI�\���̏ꍇ�j�ւ̎Q�Ƃ�Ԃ��Ȃ��Ă͂Ȃ�܂���B</p><p>�ȉ��̊ȒP�ȗ��<span class="en">%files</span>�n�b�V������̃��O�A <span class="en">$datadir/just/one/story.txt</span>�Ɋ֘A�t�����܂��F</p><pre class="en">
+</pre><p>このようにすると後続のプラグインは標準の<span class="en">template</span>サブルーチンを上書きする機会を与えられます。</p><h3>...サブルーチン ...<span class="be">entries</span></h3><p><span class="be">entries</span>サブルーチンはデフォルトの記事検索サブルーチン（貴方の全てのウェブログ記事を見つける）を置き換える機会を提供します。</p><p> <span class="be">entries</span>フックは<span class="en">Blosxom</span>本体で<span class="en">$entries</span>として定義されてる標準のものを扱う匿名関数への参照を返さなくてはなりません。</p><p>サブルーチンはファイルのハッシュと他のインデックス（静的表示の場合）への参照を返さなくてはなりません。</p><p>以下の簡単な例は<span class="en">%files</span>ハッシュを一つのログ、 <span class="en">$datadir/just/one/story.txt</span>に関連付けします：</p><pre class="en">
 sub entries {
   # 
   return sub {
@@ -152,17 +152,17 @@ sub entries {
     # indexes to be constructed when building statically
      return (\%files, \%indexes);
    };
-}</pre><p>��葍���I�Ō����I�ȗႪ<a href="plugin_registry.html" class="en">entries_index</a>�v���O�C���Ō����܂��B</p><p>�W���̂��̂��㏑���������Ȃ��ꍇ�ɂ͒P�ɖ���`�̒l��Ԃ��悤�ɂ��܂��F</p><pre class="en">
+}</pre><p>より総合的で現実的な例が<a href="plugin_registry.html" class="en">entries_index</a>プラグインで見られます。</p><p>標準のものを上書きしたくない場合には単に未定義の値を返すようにします：</p><pre class="en">
 sub entries {
   # 
     return undef;
 }
-</pre><p>�㑱�̃v���O�C���͕W����<span class="en">entries</span>�T�u���[�`�����㏑���ł���@���^�����܂��B</p><h3>...�T�u���[�`�� ...<span class="be">filter</span></h3><p><span class="be">filter</span>�T�u���[�`����<a href="doc_users_configure.html">�f�[�^�f�B���N�g��</a>��<span class="en">Blosxom</span>���������S�Ă̋L���̃��X�g��ύX����@���^���܂��B</p><p>�T�u���[�`���ɂ̓t�@�C���̃n�b�V���ւ̃��t�@�����X�i<span class="be">$files_ref</span>�j��n���܂��B�n�b�V���� �L�[/�l ����Ȃ�A�L�[�͋L���̃t���p�X�ŁA�l��<span class="en">Unix</span>�`���̏C�����ԁi<span class="en">mtime</span>�j�ł��B</p><pre class="en">
+</pre><p>後続のプラグインは標準の<span class="en">entries</span>サブルーチンを上書きできる機会を与えられます。</p><h3>...サブルーチン ...<span class="be">filter</span></h3><p><span class="be">filter</span>サブルーチンは<a href="doc_users_configure.html">データディレクトリ</a>で<span class="en">Blosxom</span>が見つけた全ての記事のリストを変更する機会を与えます。</p><p>サブルーチンにはファイルのハッシュへのリファレンス（<span class="be">$files_ref</span>）を渡します。ハッシュは キー/値 からなり、キーは記事のフルパスで、値は<span class="en">Unix</span>形式の修正時間（<span class="en">mtime</span>）です。</p><pre class="en">
 sub filter {
    my($pkg, $files_ref) = @_;
    1;
 }
-</pre><p>�t�B���^�����O�̈�̗�Ƃ��āA���[�J�������̌��ʂɊ�Â��ă��X�g���č\�z������̂��Љ�܂��B������s��<span class="en">Lucene</span>�v���O�C�������̃T�C�g�Ŏg���Ă��܂��B�ȉ��̗��<span class="en">&quot;spiffy&quot;</span>�ƌ����P����܂܂Ȃ��S�Ẵt�@�C������菜���܂��F</p><pre class="en">
+</pre><p>フィルタリングの一つの例として、ローカル検索の結果に基づいてリストを再構築するものを紹介します。これを行う<span class="en">Lucene</span>プラグインを私のサイトで使っています。以下の例は<span class="en">&quot;spiffy&quot;</span>と言う単語を含まない全てのファイルを取り除きます：</p><pre class="en">
 sub filter {
    my($pkg, $files_ref) = @_;
 
@@ -171,25 +171,25 @@ sub filter {
    }
    1;
 }
-</pre><p>1�ŃT�u���[�`�����I�����Ă��邱�Ƃɒ��ӂ��ĉ������B�Ӑ}�����悤�ɓ��삵���ꍇ��<span class="en">true</span>�i1�j��Ԃ��̂����������V�ł��B��肪���������ɂ�<span class="en">false</span>�i0�j��Ԃ��悤�ɂ��܂��B<span class="en">Blosxom</span>��0�̎��s�≽�����s�����������ɒ��f���܂���B�ÓI�ɓ��삵�Ă��鎞�Ɋe�v���O�C���ŉ����N�������������|�[�g���܂��B</p><h3>...�T�u���[�`�� ...<span class="be">skip</span></h3><p><span class="be">skip</span>�T�u���[�`����<span class="en">Blosxom</span>�����ۂɏo�͂𐶐�����̂��J�n���鎞�ɌĂяo����܂��B�v���O�C����<span class="bl">1</span>��Ԃ����ƂŃ��O��Z���؂�o�������ł��܂��B�������<span class="bl">1</span>��Ԃ��ŏ��̃v���O�C���͌Ăяo���ꂽ�Ō�̃v���O�C���ł��B</p><p><span class="be">skip</span>���[�`���͕֗��ŁA�Ⴆ�΁A�v���O�C�������炩�̗��R�ɂ�胊�_�C���N�g��Ԃ�����A�u���E�U�Ƀo�C�i���X�g���[���𑗐M������i��@�摜�j�A�킴�킴�E�F�u���O�̋L���𐶐����闝�R�������ꍇ�Ȃǂł��B</p><h3>...�T�u���[�`�� ...<span class="be">interpolate</span></h3><p><span class="be">interpolate</span>�T�u���[�`���̓f�t�H���g�̒u���T�u���[�`����u��������@���񋟂��܂��i<span class="be">$title</span>��<span class="be">$someplugin::somevariale</span>��u�������܂��j�B</p><p><span class="be">interpolate</span>���t�b�N����ŏ��̃v���O�C����<span class="en">blosxom.cgi</span>���̂̒���<span class="be">$interpolate</span>�Ɋ֘A�����R�[�h�����f�t�H���g�̏ꏊ�Ŏg���铽���֐��ւ̃��t�@�����X��Ԃ��܂��B</p><p><span class="be">$interpolate</span>�Ɋ��蓖�Ă�ꂽ�T�u���[�`���̓e���v���[�g�R���|�[�l���g���Ăяo���܂��i��@<span class="en">head</span>�A<span class="en">story</span>�A<span class="en">foot</span>�j�B�K�؂Ȓu���̂��߂ɃR���e���c��n���܂��B</p><p><a href="plugin_registry.html" class="en">interpolate_conditional</a>�v���O�C���́A�Ⴆ�΁A���̂��̂��܂ޏ����t�u���̑S�Ă̖񑩂�񋟂��܂��B��`���ꂽ�A��`����Ă��Ȃ��A*�Ɉ�v�A*���傫���A*��菬�����A�ċA�i�b�莩�̖����Ƀe���v���[�g�ϐ����g�����Ƃŉ\�ł��j�B</p><p>�v���O�C���������㏑�����������Ȃ��ꍇ�ɂ͒P�ɖ���`�̒l��Ԃ����悤�ɂ��܂��F</p><pre class="en">
+</pre><p>1でサブルーチンが終了していることに注意して下さい。意図したように動作した場合に<span class="en">true</span>（1）を返すのが正しい流儀です。問題が生じた時には<span class="en">false</span>（0）を返すようにします。<span class="en">Blosxom</span>は0の実行や何か実行が厳しい時に中断しません。静的に動作している時に各プラグインで何が起こったかをレポートします。</p><h3>...サブルーチン ...<span class="be">skip</span></h3><p><span class="be">skip</span>サブルーチンは<span class="en">Blosxom</span>が実際に出力を生成するのを開始する時に呼び出されます。プラグインは<span class="bl">1</span>を返すことでログを短く切り出す事ができます。もちろん<span class="bl">1</span>を返す最初のプラグインは呼び出された最後のプラグインです。</p><p><span class="be">skip</span>ルーチンは便利で、例えば、プラグインが何らかの理由によりリダイレクトを返したり、ブラウザにバイナリストリームを送信したり（例　画像）、わざわざウェブログの記事を生成する理由が無い場合などです。</p><h3>...サブルーチン ...<span class="be">interpolate</span></h3><p><span class="be">interpolate</span>サブルーチンはデフォルトの置換サブルーチンを置き換える機会を提供します（<span class="be">$title</span>と<span class="be">$someplugin::somevariale</span>を置き換えます）。</p><p><span class="be">interpolate</span>をフックする最初のプラグインは<span class="en">blosxom.cgi</span>自体の中の<span class="be">$interpolate</span>に関連したコードを持つデフォルトの場所で使われる匿名関数へのリファレンスを返します。</p><p><span class="be">$interpolate</span>に割り当てられたサブルーチンはテンプレートコンポーネントを呼び出します（例　<span class="en">head</span>、<span class="en">story</span>、<span class="en">foot</span>）。適切な置換のためにコンテンツを渡します。</p><p><a href="plugin_registry.html" class="en">interpolate_conditional</a>プラグインは、例えば、次のものを含む条件付置換の全ての約束を提供します。定義された、定義されていない、*に一致、*より大きい、*より小さい、再帰（話題自体無いにテンプレート変数を使うことで可能です）。</p><p>プラグインが何も上書きをしたくない場合には単に未定義の値を返しすようにします：</p><pre class="en">
 sub interpolate {
    # for some reason determine that you don't want to override the default...
    return undef;
 }
-</pre><p>�㑱�̃v���O�C���͕W���̒u���T�u���[�`�����㏑������@��𓾂܂��B</p>
-<h3><a name="head" class="anc">...�T�u���[�`�� ...<span class="be">head</span></a></h3><p><span class="en">Bloxsom</span>��<strong class="se">head.flavour</strong>�œǂݍ��񂾌�A�����ăe���v���[�g�R���|�[�l���g�ɑ΂��Ēl�̓���ւ����s���O��<span class="be">head</span>�T�u���[�`�����Ăяo���܂��B</p><p>���̃T�u���[�`���ɂ͌��݂̍�ƃf�B���N�g���i�p�X�Œ�`����Ă���j�Ɛ���<strong class="se">head.flavour</strong>�\�[�X�ւ̎Q�Ƃ�n���܂��B</p><pre class="en">
+</pre><p>後続のプラグインは標準の置換サブルーチンを上書きする機会を得ます。</p>
+<h3><a name="head" class="anc">...サブルーチン ...<span class="be">head</span></a></h3><p><span class="en">Bloxsom</span>は<strong class="se">head.flavour</strong>で読み込んだ後、そしてテンプレートコンポーネントに対して値の入れ替えを行う前に<span class="be">head</span>サブルーチンを呼び出します。</p><p>このサブルーチンには現在の作業ディレクトリ（パスで定義されている）と生の<strong class="se">head.flavour</strong>ソースへの参照を渡します。</p><pre class="en">
 sub head {
    my($pkg, $currentdir, $head_ref) = @_;
    1;
 }
-</pre><p><span class="be">head</span>�T�u���[�`���͏o�̓X�g���[�����w�b�_�ɒǉ�����O�ɐ��̃w�b�_�\�[�X��ύX���A�܂��͉��炩�̕ϐ���ύX����@���񋟂��܂��B</p><p>����͂܂��A�����̃J�X�^���Șb��Ɋ֌W�̖����e���v���[�g�ϐ���ύX����̂ɗǂ���i�ł��B�����ł́A�Ⴆ�΁A�^�C�g���ւ�<span class="be">URL</span>�s�ɓn�����p�X��ǉ����Ă��܂��B<span class="be">&quot;::&quot;</span>�ł͂��܂�Ă��܂��B</p><pre class="en">
+</pre><p><span class="be">head</span>サブルーチンは出力ストリームをヘッダに追加する前に生のヘッダソースを変更し、または何らかの変数を変更する機会を提供します。</p><p>これはまた、これらのカスタムな話題に関係の無いテンプレート変数を変更するのに良い手段です。ここでは、例えば、タイトルへの<span class="be">URL</span>行に渡したパスを追加しています。<span class="be">&quot;::&quot;</span>ではさまれています。</p><pre class="en">
 sub head {
    my($pkg, $currentdir, $head_ref) = @_;
    $title_and_path = $blosxom::blog_title;
    $blosxom::path_info and $title_and_path .= &quot; :: /$blosxom::path_info&quot;;
    1;
 }
-</pre><p>���͎���<span class="be">head.flavour</span>��<span class="be">$blog_title::$path_info</span>��P���Ɋ܂߂鎖�ł����B�����Ă��܂���B�Ȃ��Ȃ�<span class="en">URL</span>�s�Ƀp�X�����肳��Ă��Ȃ��ꍇ��<span class="en">&quot;::&quot;</span>���\������Ă��܂��̂ŁA<span class="en">&quot;raelity bytes::&quot;</span>���쐬���Ă��܂��B</p><p>��莎���I�ł͂Ȃ���͎��̃T�C�g�Ŏg�p���Ă���<span class="en">readme</span>�v���O�C�����쐬���邽�߂Ɏg���Ă��܂��B���݂̍�ƃf�B���N�g���i<span class="be">$currentdir</span>�j�Ɍ���ꂽ<strong class="se">readme</strong>�A�܂���<strong class="se">readme.flavour</strong>�t�@�C�����ǂݍ��܂�A���̃w�b�_�\�[�X�ɒǉ�����܂��i<span class="be">$head_ref</span>�j�B</p><h3>...�T�u���[�`�� ...<span class="be">sort</span></h3><p><span class="en">sort</span>�T�u���[�`���͕\������E�F�u���O�̏��ԁi�W���ł͓��t���F�V�����̂��ŏ��j�����肷��W���̕��בւ��T�u���[�`����u��������@���񋟂��܂��B</p><p><span class="en">entries</span>�t�b�N��<span class="en">blosxom.cgi</span>�{�̂�<span class="en">$entries</span>�Ɋ��蓖�Ă��Ă��W���̏ꏊ�Ŏg���Ă������֐��ւ̎Q�Ƃ�Ԃ��Ȃ��Ă͂Ȃ�܂���B</p><p>���̃T�u���[�`���͊��S����̃t�@�C�����̃��X�g��Ԃ��Ȃ��Ă͂Ȃ�܂���B</p><p>�ȉ��̗�͓��t���i�Â��̂���j�ŋL������בւ��܂��B����͕W���Ƃ͋t�ł��F</p><pre class="en">
+</pre><p>私は私の<span class="be">head.flavour</span>に<span class="be">$blog_title::$path_info</span>を単純に含める事でこれを達成していません。なぜなら<span class="en">URL</span>行にパスが特定されていない場合に<span class="en">&quot;::&quot;</span>が表示されてしまうので、<span class="en">&quot;raelity bytes::&quot;</span>を作成しています。</p><p>より試験的ではない例は私のサイトで使用している<span class="en">readme</span>プラグインを作成するために使っています。現在の作業ディレクトリ（<span class="be">$currentdir</span>）に現われた<strong class="se">readme</strong>、または<strong class="se">readme.flavour</strong>ファイルが読み込まれ、生のヘッダソースに追加されます（<span class="be">$head_ref</span>）。</p><h3>...サブルーチン ...<span class="be">sort</span></h3><p><span class="en">sort</span>サブルーチンは表示するウェブログの順番（標準では日付順：新しいのが最初）を決定する標準の並べ替えサブルーチンを置き換える機会を提供します。</p><p><span class="en">entries</span>フックは<span class="en">blosxom.cgi</span>本体で<span class="en">$entries</span>に割り当てられてた標準の場所で使われてい匿名関数への参照を返さなくてはなりません。</p><p>このサブルーチンは完全限定のファイル名のリストを返さなくてはなりません。</p><p>以下の例は日付順（古いのが先）で記事を並べ替えます。これは標準とは逆です：</p><pre class="en">
 sub sort {
    return sub {
      my($files_ref) = @_;
@@ -197,18 +197,18 @@ sub sort {
      %$files_ref;
    };
 }
-</pre><p>�����㏑���������Ȃ��ꍇ�ɂ͒P��1��Ԃ����悤�ɂ��܂��F</p><pre class="en">
+</pre><p>何も上書きしたくない場合には単に1を返しすようにします：</p><pre class="en">
 sub sort {
   #
   return undef;
 }
-</pre><p>�㑱�̃v���O�C���͕W���̕��בւ��T�u���[�`�����㏑������@��𓾂܂��B</p><h3>..�T�u���[�`�� ...<span class="be">date</span></h3><p><span class="en">Bloxsom</span>�͓��t���V�����Ȃ��<span class="en">date</span>���Ăяo���܂��B����͓K�؂�<strong class="se">date.flavour</strong>�ŕ\��������ŁA�����ăe���v���[�g�R���|�[�l���g�̂��߂̒l�����ւ���O�ł��B</p><p>���̃T�u���[�`���ɂ͌��݂̃f�B���N�g���Ɛ���<strong class="se">date.flavour</strong>�\�[�X�A<span class="en">Unix</span>�X�^�C���̓��t�ɑ΂���ŐV�̋L���̏C�����A�����ďC�������痈�����֗̕��ȓ��t���n����܂��B</p><pre class="en">
+</pre><p>後続のプラグインは標準の並べ替えサブルーチンを上書きする機会を得ます。</p><h3>..サブルーチン ...<span class="be">date</span></h3><p><span class="en">Bloxsom</span>は日付が新しくなると<span class="en">date</span>を呼び出します。それは適切な<strong class="se">date.flavour</strong>で表示した後で、そしてテンプレートコンポーネントのための値を入れ替える前です。</p><p>このサブルーチンには現在のディレクトリと生の<strong class="se">date.flavour</strong>ソース、<span class="en">Unix</span>スタイルの日付に対する最新の記事の修正日、そして修正日から来る幾つかの便利な日付が渡されます。</p><pre class="en">
 sub date { 
   my ($pkg, $currentdir, $date_ref, $mtime, @date_bits) = @_;
   my($dw,$mo,$mo_num,$da,$ti,$yr) = @date_bits;
   1; 
 }
-</pre><p><span class="be">date</span>�͐���<span class="en">date</span>�e���v���[�g�̏C���Ɗ��S�ɐV�������t�̍\�z�̋@���񋟂��Ă��܂��B�ȉ��̃R�[�h�́A�Ⴆ�΁A�p��̌��̖��O���t�����X��A���{�ꓙ�ɕϊ����܂��B</p><pre class="en">
+</pre><p><span class="be">date</span>は生の<span class="en">date</span>テンプレートの修正と完全に新しい日付の構築の機会を提供しています。以下のコードは、例えば、英語の月の名前をフランス語、日本語等に変換します。</p><pre class="en">
 sub date {
    my ($pkg, $date_ref, $mtime, $dw,$mo,$mo_num,$da,$ti,$yr) = @_;
    # 
@@ -216,18 +216,18 @@ sub date {
    1;
 }
 </pre>
-<h3>...�T�u���[�`�� ...<span class="be">story</span></h3><p><span class="en">Bloxsom</span>��<span class="be">story</span>���e�X�A�����đS�Ă̋L���ɑ΂��ČĂяo���܂��B����͓K�؂�<strong class="se">story.fvalour</strong>�œǂݍ��񂾌�ƁA�e���v���[�g�R���|�[�l���g�ɑ΂��Ēl�����ւ���O�ł��B</p><p>���̃T�u���[�`���ɂ͋L���̃p�X�A�t�@�C�����A����<strong class="se">story.flavour</strong>�\�[�X�ւ̎Q�ƁA�L���̃^�C�g���ւ̎Q�ƁA�����ċL���̖{���ւ̎Q�Ƃ��n����܂��B</p><pre class="en">
+<h3>...サブルーチン ...<span class="be">story</span></h3><p><span class="en">Bloxsom</span>は<span class="be">story</span>を各々、そして全ての記事に対して呼び出します。それは適切な<strong class="se">story.fvalour</strong>で読み込んだ後と、テンプレートコンポーネントに対して値を入れ替える前です。</p><p>このサブルーチンには記事のパス、ファイル名、生の<strong class="se">story.flavour</strong>ソースへの参照、記事のタイトルへの参照、そして記事の本文への参照が渡されます。</p><pre class="en">
 sub story {
    my ($pkg, $path, $filename, $story_ref, $title_ref, $body_ref)
    1;
 }
-</pre><p>����<span class="en">story.flavour</span>�\�[�X�̕ύX�A�e���v���[�g�ɓn�����O�Ƀ^�C�g���Ɩ{���̕ύX�����s���܂��B</p><p>�ȒP�ȗ�Ƃ��āA�E�F�u���O�̔ԍ���\��<span class="be">$story_number</span>�ϐ����g���Ă݂܂��傤�B</p><pre class="en">
+</pre><p>生の<span class="en">story.flavour</span>ソースの変更、テンプレートに渡される前にタイトルと本文の変更等が行えます。</p><p>簡単な例として、ウェブログの番号を表す<span class="be">$story_number</span>変数を使ってみましょう。</p><pre class="en">
 sub story {
    my ($pkg, $path, $filename, $story_ref, $title_ref, $body_ref)
    $$title_ref = &quot;#&quot; . $story_number++ . &quot;. &quot; . $$title_ref;
    1;
 }
-</pre><p>�܂��́A���ǂ���Ƃ��Ď��̃T�C�g�Ŏg���Ă���P���������i�\���ł͗L��܂��񂪁j<span class="en">TrackBack</span>�v���O�C���������Ă݂܂��傤�B����̓X�^���h�A������<span class="en">TrackBack</span>����g���b�N�o�b�N�̐������o���A<span class="en">$trackback</span>�ϐ��Ɍ��ʂ�ۑ����܂��B�l�͎���<span class="be">story.flavour</span>����<span class="en">$trackbacks::trackback</span>�Ɠ���ւ����܂��B</p><pre class="en">
+</pre><p>または、より良い例として私のサイトで使っている単純化した（十分では有りませんが）<span class="en">TrackBack</span>プラグインをあげてみましょう。これはスタンドアロンの<span class="en">TrackBack</span>からトラックバックの数を取り出し、<span class="en">$trackback</span>変数に結果を保存します。値は私の<span class="be">story.flavour</span>内で<span class="en">$trackbacks::trackback</span>と入れ替えられます。</p><pre class="en">
 $trackback = '';
 
 sub story {
@@ -239,16 +239,16 @@ sub story {
      qq{&lt;a href=&quot;$tb_url?__mode=list&amp;tb_id=$tb_id&quot;&gt;trackbacks ($tb_count)&lt;/a&gt;};
    1;
 }
-</pre><h3>..�T�u���[�`�� ...<span class="be">foot</span></h3><p><a href="#head"><span class="en">head</span>�T�u���[�`��</a>�Ǝ��āi���R�[�h��A�ʂ�B�ʂ̂悤�Ȋ֌W�j�A<span class="en">Blosxom</span>�͓K�؂�<strong class="se">foot.flavour</strong>�œǂݍ��񂾌�A�����ăe���v���[�g�R���|�[�l���g�ɑ΂���l�̓���ւ��̑O��<span class="be">foot</span>�T�u���[�`�����Ăяo���܂��B</p><p>���̃T�u���[�`���ɂ͌��݂̍�ƃf�B���N�g���i�p�X�Œ�`�����j�Ɛ���<span class="en">foot.flavour</span>�\�[�X�ւ̎Q�Ƃ��n����܂��B</p><pre class="en">
+</pre><h3>..サブルーチン ...<span class="be">foot</span></h3><p><a href="#head"><span class="en">head</span>サブルーチン</a>と似て（レコードのA面とB面のような関係）、<span class="en">Blosxom</span>は適切な<strong class="se">foot.flavour</strong>で読み込んだ後、そしてテンプレートコンポーネントに対する値の入れ替えの前に<span class="be">foot</span>サブルーチンを呼び出します。</p><p>このサブルーチンには現在の作業ディレクトリ（パスで定義される）と生の<span class="en">foot.flavour</span>ソースへの参照が渡されます。</p><pre class="en">
 sub foot {
    my($pkg, $currentdir, $foot_ref) = @_;
    1;
 }
-</pre><p><span class="be">foot</span>�T�u���[�`���͐��̃t�b�^�\�[�X�̕ύX��o�̓X�g���[���ւ̃t�b�^�̒ǉ��̑O�̕ϐ��̕ύX��񋟂��܂��B</p><h3>...�T�u���[�`�� ...<span class="be">end</span></h3><p><span class="en">end</span>�T�u���[�`���͍Ō�ɌĂяo����܂��B����͑S�Ă̏o�͂���������ău���E�U�ɑ���ꂽ��ŁA<span class="en">Blosxom</span>�����s���I������O�ł��B</p><pre class="en">
+</pre><p><span class="be">foot</span>サブルーチンは生のフッタソースの変更や出力ストリームへのフッタの追加の前の変数の変更を提供します。</p><h3>...サブルーチン ...<span class="be">end</span></h3><p><span class="en">end</span>サブルーチンは最後に呼び出されます。それは全ての出力が処理されてブラウザに送られた後で、<span class="en">Blosxom</span>が実行を終了する前です。</p><pre class="en">
 sub end {
    1;
 }
-</pre><p>���̃T�u���[�`���ɂ͉����n����܂���B</p><p>�����̓N���[���i�b�v�܂��͕֗��Ǝv���������s���Ō�̏ꏊ�ł��B���͂�������̗��p���@�������܂����B�����<span class="en">&quot;touch file&quot;</span>�̏C�������牽���ύX������ꍇ���ǂ���<span class="en">weblogs.com</span>��<span class="en">ping</span>��ł����艽���Ԃ��o�߂������ƂɐV�����E�F�u���O�𓊍e�����ƌ����������[�����O���X�g�Ƀ��[���𑗐M����悤�Ȏg�����ł��B</p><h3>...�T�u���[�`�� ...<span class="be">last</span></h3><p><span class="en">last</span>�T�u���[�`���t�b�N�̓u���E�U�ŕ\�������A�܂��̓t�@�C����ۑ�����i�ÓI�\���̏ꍇ�j�ƌ��������A�w�b�_���o�͂���A�S�Ă�<span class="en">kit-and-karboodle</span>���������[�`���ŕԂ����O�ɌĂяo����܂��B</p><p>���̃T�u���[�`���ɂ�<span class="en">Blosxom</span>���牽���n����܂���B</p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</pre><p>このサブルーチンには何も渡されません。</p><p>ここはクリーンナップまたは便利と思う処理を行う最後の場所です。私はたくさんの利用方法を見つけました。それは<span class="en">&quot;touch file&quot;</span>の修正日から何か変更がある場合かどうか<span class="en">weblogs.com</span>に<span class="en">ping</span>を打ったり何時間も経過したあとに新しいウェブログを投稿したと言う事をメーリングリストにメールを送信するような使い方です。</p><h3>...サブルーチン ...<span class="be">last</span></h3><p><span class="en">last</span>サブルーチンフックはブラウザで表示される、またはファイルを保存する（静的表示の場合）と言うよりも、ヘッダが出力され、全ての<span class="en">kit-and-karboodle</span>が生成ルーチンで返される前に呼び出されます。</p><p>このサブルーチンには<span class="en">Blosxom</span>から何も渡されません。</p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_dev_plugins.html
+++ b/doc_dev_plugins.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_dev_plugins.html
+++ b/doc_dev_plugins.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::開発者向け - プラグイン</title>
 

--- a/doc_users_blog.html
+++ b/doc_users_blog.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�E�F�u���O</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::ウェブログ</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,64 +11,64 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�E�F�u���O</a></h1><p><span class="en">Blosxom</span>�ŃE�F�u���O���쐬���邱�Ƃ͂���قǒP���ł͂���܂���B�C�̐��E�ł͓����������쐶�̒��Ŏ��R�ɐU�����̂Ɠ��l�ɁA<span class="en">Blosxom</span>�͋M���̏�������ς���悤�Ȃ��Ƃ͂��܂���B�D���ȃe�L�X�g�G�f�B�^�i<span class="en">BBEdit</span>�A�������A<span class="en">Emacs</span>�A<span class="en">Word</span>���j���g���ĕҏW���s���܂��B�u���E�U�ŕҏW�ł���悤�Ȃ��̂͂���܂���B�ł��̂Ńe�L�X�g�G�f�B�^����g���Ă��������B</p>
-<h2>�E�F�u���O</h2><h3>�L���͂����̃e�L�X�g�t�@�C��...</h3><p>�S�ẴE�F�u���O��<span class="en">Blosxom</span>�̃f�[�^�f�B���N�g��/�t�H���_�ɕۑ��������ʂ̃e�L�X�g�t�@�C���ł��B�B��̌��܂�̓t�@�C������<span class="be">.txt</span> �i�܂��͐ݒ�ŋM�����w�肵���g���q�j�ŏI��邱�Ƃł��B����ȊO�̂��͖̂�������܂��B</p><p>�L���͑��Ɠ��l�ɒP�Ȃ�t�@�C���Ȃ̂ŁA���ɂ���L����ҏW����ɂ̓e�L�X�g�G�f�B�^�ŊJ���ē��e��ύX���A�ۑ�����Ηǂ��ł��B</p><p>�L���̍폜�͖ړI�̃t�@�C�����폜�A�܂��͖��O�ύX�i<span class="be">.txt</span>�ȊO�̉����ɕύX�j���邾���ł��B</p><p>
-�֗��ɁF ���������̋L����<span class="be">.txt</span>�ȊO�̋M���̍D���Ȋg���q�ɂ��ĕۑ�����΁A<span class="en">Blosxom</span>�͂��̃t�@�C�������o���Ȃ��̂ŕ֗��ł��B����������g���q��<span class="en">.txt</span>�ɕύX����΂悢�̂ł��B</p>
-<h3>�L���̏���...</h3><p>�L���̏����͂قڎ��R�ł��B�B��̖񑩂́A�ŏ��̍s���薼�ɂȂ�̂ŒZ���A���ǎ҂̋C�������悤��&quot;�Â�����&quot;�ɂ���悤�ɂ��ĉ������B�c��̍s�̓e�L�X�g�ƉԒd����邽�߂�<span class="en">HTML</span>���g���ċM���̐S��\�����ĉ������B�T�^�I�ȋL�����Љ�܂��F</p><pre>
-�T�^�I�ȋL��
-�M���̓T�^�I��<span class="en">&lt;a href=&quot;http://www.blosxom.com/&quot;&gt;Blosxom&lt;/a&gt;</span>
-�̋L���͍ŏ��̍s�̃^�C�g���ƃe�L�X�g��<span class="en">HTML</span>�ŏ����ꂽ�{���ō\������܂��B
+<td id="contents"><h1><a name="top" class="bl">ウェブログ</a></h1><p><span class="en">Blosxom</span>でウェブログを作成することはそれほど単純ではありません。海の世界では動物たちが野生の中で自然に振舞うのと同様に、<span class="en">Blosxom</span>は貴方の書き方を変えるようなことはしません。好きなテキストエディタ（<span class="en">BBEdit</span>、メモ帳、<span class="en">Emacs</span>、<span class="en">Word</span>等）を使って編集を行います。ブラウザで編集できるようなものはありません。ですのでテキストエディタを駆使してください。</p>
+<h2>ウェブログ</h2><h3>記事はただのテキストファイル...</h3><p>全てのウェブログは<span class="en">Blosxom</span>のデータディレクトリ/フォルダに保存した普通のテキストファイルです。唯一の決まりはファイル名が<span class="be">.txt</span> （または設定で貴方が指定した拡張子）で終わることです。それ以外のものは無視されます。</p><p>記事は他と同様に単なるファイルなので、既にある記事を編集するにはテキストエディタで開いて内容を変更し、保存すれば良いです。</p><p>記事の削除は目的のファイルを削除、または名前変更（<span class="be">.txt</span>以外の何かに変更）するだけです。</p><p>
+便利に： 書きかけの記事は<span class="be">.txt</span>以外の貴方の好きな拡張子にして保存すれば、<span class="en">Blosxom</span>はそのファイルを取り出さないので便利です。完成したら拡張子を<span class="en">.txt</span>に変更すればよいのです。</p>
+<h3>記事の書式...</h3><p>記事の書式はほぼ自由です。唯一の約束は、最初の行が題名になるので短く、かつ読者の気を引くような&quot;甘い香り&quot;にするようにして下さい。残りの行はテキストと花壇を作るための<span class="en">HTML</span>を使って貴方の心を表現して下さい。典型的な記事を紹介します：</p><pre>
+典型的な記事
+貴方の典型的な<span class="en">&lt;a href=&quot;http://www.blosxom.com/&quot;&gt;Blosxom&lt;/a&gt;</span>
+の記事は最初の行のタイトルとテキストと<span class="en">HTML</span>で書かれた本文で構成されます。
 </pre>
-<h3 class="bl">�ۑ�...</h3><p>�L����<span class="en">Blosxom</span>�̃f�[�^�f�B���N�g��/�t�H���_�i�܂��͂��̂ǂ������j�ɕۑ����ĉ������B�J�e�S�����Ƃɓǂ񂾂�A�E�F�u���O�����L����悤�ȋ@�������܂ł̓f�[�^�f�B���N�g�����Œ肵�Ă����̂��x�X�g�ł��傤�B</p><p>�܂��L���������쐬���Ă��Ȃ��A<span class="en">Blosxom</span>�̃C���X�g�[���Ɛݒ���ς܂����΂���ł���Ȃ�΂��ЁA���������Ă݂ĉ������B</p><p class="nextLink"><a href="doc_users_view.html" class="bl">�M���̃E�F�u���O�����Ă݂�i�ŏ��̋L���j</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<h3 class="bl">保存...</h3><p>記事は<span class="en">Blosxom</span>のデータディレクトリ/フォルダ（またはそのどこか下）に保存して下さい。カテゴリごとに読んだり、ウェブログを共有するような機会が生じるまではデータディレクトリを固定しておくのがベストでしょう。</p><p>まだ記事を何も作成していなく、<span class="en">Blosxom</span>のインストールと設定を済ませたばかりであるならばぜひ、何か書いてみて下さい。</p><p class="nextLink"><a href="doc_users_view.html" class="bl">貴方のウェブログを見てみる（最初の記事）</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_blog.html
+++ b/doc_users_blog.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_blog.html
+++ b/doc_users_blog.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::ウェブログ</title>
 

--- a/doc_users_configure.html
+++ b/doc_users_configure.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_configure.html
+++ b/doc_users_configure.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::環境設定</title>
 

--- a/doc_users_configure.html
+++ b/doc_users_configure.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::���ݒ�</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::環境設定</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,56 +11,56 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">���ݒ�</a></h1><h2><a name="configure" class="anc">�ݒ�</a></h2><p> <span class="en">Blosxom</span>�̑S�Ă̐ݒ�͊ȒP�̂��߃X�N���v�g���g�ɏ�����Ă��܂��B����鎖�͂���܂���B�S�Ăɖʔ����������t���Ă��܂����A�{���ɒP���ł��B�W���ł͈ȉ��̂悤�ɂȂ��Ă��܂��F</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl">環境設定</a></h1><h2><a name="configure" class="anc">設定</a></h2><p> <span class="en">Blosxom</span>の全ての設定は簡単のためスクリプト自身に書かれています。恐れる事はありません。全てに面白い文字が付いていますし、本当に単純です。標準では以下のようになっています：</p><pre class="en">
 # --- Configurable variables -----
 
 # What's this blog's title?
@@ -98,54 +98,54 @@ $show_future_entries = 0;
 ...
 
 # --------------------------------
-</pre><p>�e�ݒ�f�B���N�e�B�u�͐ݒ薼�ō\������Ă��܂��i�� <span class="be">$static_dir</span>�A =�L���A�ݒ�l�i��@<span class="be">&quot;/Library/WebServer/Documents/blog&quot;</span>�@�����̏ꍇ��&quot;�ň݂͂܂��B�����̏ꍇ��&quot;�ň݂͂܂���j�B�ݒ�l��ς���ꍇ�ɂ͖]�ޒl�ŒP���ɒu��������Ηǂ��ł��B&quot;���������ꍇ�ɂ͎c���Ēu���ĉ������B</p><p>�Ⴆ�΁A�E�F�u���O�̃^�C�g����W������ύX����ɂ́i<span class="be">My Weblog</span>����<span class="be">Sam's 
-Insights</span>�Ɂj���̂悤�ɂȂ�܂��F<span class="be">$blog_title = &quot;Sam's Insights&quot;;</span></p><p>������܂������H�@�ǂ��ł��傤�B���ɐi�݂܂��傤�B</p><dl> 
+</pre><p>各設定ディレクティブは設定名で構成されています（例 <span class="be">$static_dir</span>、 =記号、設定値（例　<span class="be">&quot;/Library/WebServer/Documents/blog&quot;</span>　文字の場合は&quot;で囲みます。数字の場合は&quot;で囲みません）。設定値を変える場合には望む値で単純に置き換えれば良いです。&quot;があった場合には残して置いて下さい。</p><p>例えば、ウェブログのタイトルを標準から変更するには（<span class="be">My Weblog</span>から<span class="be">Sam's 
+Insights</span>に）次のようになります：<span class="be">$blog_title = &quot;Sam's Insights&quot;;</span></p><p>分かりましたか？　良いでしょう。次に進みましょう。</p><dl> 
 <dt class="bl"><span class="en">$blog_title</span></dt>
 <dd> 
-<p>�E�F�u���O�̕W���̃^�C�g���B���̃^�C�g����<a href="doc_users_flavour.html">�t���[�o�[�e���v���[�g</a>�Ŏg���܂��B�܂�<a href="doc_users_syndicate.html">�V���W�P�[�g</a><span class="en">RSS</span>�̃^�C�g���Ƃ��Ă��g���܂��B</p>
+<p>ウェブログの標準のタイトル。このタイトルは<a href="doc_users_flavour.html">フレーバーテンプレート</a>で使えます。また<a href="doc_users_syndicate.html">シンジケート</a><span class="en">RSS</span>のタイトルとしても使われます。</p>
 </dd>
 <dt class="bl"><span class="en">$blog_description</span></dt>
 <dd> 
-<p>�E�F�u���O�̕W���̐������B���̐�������<a href="doc_users_flavour.html">�t���[�o�[�e���v���[�g</a>�Ŏg���܂��B�܂�<a href="doc_users_syndicate.html">�V���W�P�[�g</a><span class="en">RSS</span>�̐������Ƃ��Ă��g���܂��B</p>
+<p>ウェブログの標準の説明文。この説明文は<a href="doc_users_flavour.html">フレーバーテンプレート</a>で使えます。また<a href="doc_users_syndicate.html">シンジケート</a><span class="en">RSS</span>の説明文としても使われます。</p>
 </dd>
 <dt class="bl"><span class="en">$blog_language</span></dt>
 <dd> 
-<p><a href="doc_users_syndicate.html">�V���W�P�[�g</a><span class="en">RSS</span>�ł̓E�F�u���O�̌����\���܂��B�W���ł͉p��ł��B<a href="http://backend.userland.com/stories/storyReader$16">���̌���̏ȗ��`�͂����œ����܂��B</a></p>
+<p><a href="doc_users_syndicate.html">シンジケート</a><span class="en">RSS</span>ではウェブログの言語を表します。標準では英語です。<a href="http://backend.userland.com/stories/storyReader$16">他の言語の省略形はここで得られます。</a></p>
 </dd>
 <dt class="bl"><span class="en">$datadir</span></dt>
 <dd> 
-<p>�ł��d�v�Ȑݒ�ŁA<span class="be">$datadir</span>�͋L�����ǂ��ɂ��邩<span class="en">Blosxom</span>�ɒm�点�܂��B�t���p�X�Ńf�B���N�g�����w�肵�܂��B</p>
+<p>最も重要な設定で、<span class="be">$datadir</span>は記事がどこにあるか<span class="en">Blosxom</span>に知らせます。フルパスでディレクトリを指定します。</p>
 </dd>
 <dt class="bl"><span class="en">$url</span></dt>
 <dd> 
-<p>��ɂ��Ă�����<span class="en">Blosxom</span>�̓E�F�u���O��URL�����ł��邩�������I�Ɍ��o���܂��B�����̏ꍇ�͂���ł��܂��s���܂��B�����Ŏw�肵�������͕ύX���܂��i�� <span class="be">$url 
-= &quot;http://www.raelity.org/&quot;;</span>�j�B</p>
+<p>空にしておくと<span class="en">Blosxom</span>はウェブログのURLが何であるかを自動的に検出します。多くの場合はこれでうまく行きます。自分で指定したい時は変更します（例 <span class="be">$url 
+= &quot;http://www.raelity.org/&quot;;</span>）。</p>
 </dd>
 <dt class="bl"><span class="en">$depth</span></dt>
 <dd> 
-<p>�J�e�S���C�Y�����苤�L�����肷��܂ł͕����Ă����̂��x�X�g�ł��B���̐ݒ��<span class="en">Blosxom</span>���f�[�^�f�B���N�g���݂̂����邩�A����Ƃ��K�w�����ɒH���Ă��������w�肵�܂��B</p>
+<p>カテゴライズしたり共有したりするまでは放っておくのがベストです。この設定は<span class="en">Blosxom</span>がデータディレクトリのみを見るか、それとも階層を下に辿っていくかを指定します。</p>
 </dd>
 <dt class="bl"><span class="en">$num_entries</span></dt>
 <dd> 
-<p>�E�F�u���O�̃z�[���y�[�W��<span class="en">Blosxom</span>����̋L����\�����邩�𐔎��Ŏw�肵�܂��B����ɂ���ČÂ��L���������ƃy�[�W�̉��ɕ\�������悤�ɂ��邩�A����Ƃ��\������Ȃ��悤�ɂ��邩�i��������E�F�u���O�������ꍇ�j�𒲐��ł��܂��B</p>
+<p>ウェブログのホームページで<span class="en">Blosxom</span>が幾つの記事を表示するかを数字で指定します。これによって古い記事がずっとページの下に表示されるようにするか、それとも表示されないようにするか（たくさんウェブログを書く場合）を調整できます。</p>
 </dd>
 <dt class="bl"><span class="en">$file_extension</span></dt>
 <dd> 
-<p><span class="en">Blosxom</span>�͕W����<span class="en">$datadir</span>����<span class="en">.txt</span>�ŏI���t�@�C����T���܂����A<span class="be">$file_extension</span>��ύX����΂����ς��邱�Ƃ��o���܂��B</p>
-<p>��@<span class="be">my $file_extension = &quot;blosxom&quot;;</span><br>
-<span class="en">Blosxom</span>��<span class="be">welcome.blosxom</span>��<span class="be">what_i_ate_for_breakfast.blosxom</span>����T���܂��B</p>
+<p><span class="en">Blosxom</span>は標準で<span class="en">$datadir</span>内の<span class="en">.txt</span>で終わるファイルを探しますが、<span class="be">$file_extension</span>を変更すればそれを変えることが出来ます。</p>
+<p>例　<span class="be">my $file_extension = &quot;blosxom&quot;;</span><br>
+<span class="en">Blosxom</span>は<span class="be">welcome.blosxom</span>や<span class="be">what_i_ate_for_breakfast.blosxom</span>等を探します。</p>
 </dd>
 <dt class="bl"><span class="en">$default_flavour</span></dt>
 <dd> 
-<p>���̐ݒ�͕W���Ŏg��<a href="doc_users_flavour.html">�t���[�o�[</a>�����肵�܂��B</p>
+<p>この設定は標準で使う<a href="doc_users_flavour.html">フレーバー</a>を決定します。</p>
 </dd>
 <dt class="bl"><span class="en">$show_future_entries</span></dt>
 <dd> 
-<p>���̐ݒ�͖����̓��t�����E�F�u���O��\�����邩 <span class="bl">(</span><span class="be">$show_future_entries = 1</span>)�A����Ƃ����̓�������܂ŉB���Ă����� 
-�i<span class="be">$show_future_entries = 0</span>�j�����肵�܂��B��҂��f�t�H���g�ł��B�����̓��t��t����ɂ�<span class="be">touch</span>�R�}���h���g���K�v������܂��B����ɕt���Ă����ƒm�肽�����<span class="en">&quot;man 
-page&quot;</span>�i<span class="en">Unix</span>�̃}�j���A���j�����ĉ������B</p>
+<p>この設定は未来の日付を持つウェブログを表示するか <span class="bl">(</span><span class="be">$show_future_entries = 1</span>)、それともその日が来るまで隠しておくか 
+（<span class="be">$show_future_entries = 0</span>）を決定します。後者がデフォルトです。未来の日付を付けるには<span class="be">touch</span>コマンドを使う必要があります。それに付いてもっと知りたければ<span class="en">&quot;man 
+page&quot;</span>（<span class="en">Unix</span>のマニュアル）を見て下さい。</p>
 </dd>
-</dl><p>�c��̐ݒ�̓v���O�C���ƐÓI�\���Ɋւ�����̂ŁA���̎���������ǂ߂Ηǂ��ł��傤�i���̃y�[�W�̏�Ŋ��ɐ������Ă��܂��j�B</p><p class="nextLink"><a href="doc_users_blog.html" class="bl">�e�X�g�̃E�F�u���O�������Ă݂�...</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</dl><p>残りの設定はプラグインと静的表示に関するもので、その時が来たら読めば良いでしょう（このページの上で既に説明しています）。</p><p class="nextLink"><a href="doc_users_blog.html" class="bl">テストのウェブログを書いてみる...</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_configure_static.html
+++ b/doc_users_configure_static.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_configure_static.html
+++ b/doc_users_configure_static.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�ÓI�\��</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::静的表示</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,137 +11,137 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�ÓI�\��</a></h1><h2>�ÓI�\��</h2><p><span class="en">Blosxom</span>��<span class="en">CGI</span>�X�N���v�g�Ƃ��ē��I�i�v���O�����ł��̓s�x�y�[�W���쐬�j�Ƀy�[�W��\�������� --�W���̐ݒ�--�A���C���̃C���f�b�N�X�A�J�e�S���C���f�b�N�X�A�����ē��t�C���f�b�N�X�ɑ΂��Ă��炩���߃t�@�C�����쐬���Ă����āA�ÓI�ɂ����\�����邽�߂̃R�}���h���C���ōs���@�\������܂��B</p><p>
-�ÓI�ȕ\���̓T�[�o���t�@�C���̂ݕ\���ł���i<span class="en">CGI</span>�X�N���v�g�����s�ł��Ȃ��j�ꍇ��A�����Ă����������ƌ����ꍇ�ɕ֗��ł��B �T�[�o�⃍�[�J�� --���b�v�g�b�v�Ƃ�-- �̃R�}���h���C���ŃE�F�u���O�y�[�W���쐬����<span class="en">WebDAV</span>�h���C�u�A<span class="en">Mac iDisk</span>�ɕۑ�������A<span class="en">FTP/rsync</span>�ŃT�[�o�ɃA�b�v���邱�Ƃ��\�ł��B</p><p>�܂������I�Ȏg�������ł��܂��B������g���b�N�o�b�N�A�@�\�Ɋւ���������ɂ̓E�F�u���O��S�ĐÓI�\���ɂ��āA�@�\��v���O�C���Ńz�[����������肱�ށA�Ȃ�Ă����ł��B</p>
-<h3>�ÓI�\���̐ݒ�...</h3><p><span class="en">Blosxom</span>�͕W���œ��I�Ƀy�[�W���쐬���܂��i<span class="en">CGI</span>�X�N���v�g�Ƃ��ē���j�B�ÓI�\����L���ɂ���ɂ͐ÓI�ȃE�F�u�y�[�W��ۑ����邽�߂̃f�B���N�g�����쐬���A�ÓI�\���p��<span class="en">Blosxom</span>�̐ݒ���s���K�v������܂��B</p>
+<td id="contents"><h1><a name="top" class="bl">静的表示</a></h1><h2>静的表示</h2><p><span class="en">Blosxom</span>は<span class="en">CGI</span>スクリプトとして動的（プログラムでその都度ページを作成）にページを表示したり --標準の設定--、メインのインデックス、カテゴリインデックス、そして日付インデックスに対してあらかじめファイルを作成しておいて、静的にそれを表示するためのコマンドラインで行う機能があります。</p><p>
+静的な表示はサーバがファイルのみ表示できる（<span class="en">CGI</span>スクリプトを実行できない）場合や、敢えてそうしたいと言う場合に便利です。 サーバやローカル --ラップトップとか-- のコマンドラインでウェブログページを作成して<span class="en">WebDAV</span>ドライブ、<span class="en">Mac iDisk</span>に保存したり、<span class="en">FTP/rsync</span>でサーバにアップすることが可能です。</p><p>また複合的な使い方もできます。検索やトラックバック、機能に関する実験中にはウェブログを全て静的表示にして、機能やプラグインでホーム部分を作りこむ、なんてやり方です。</p>
+<h3>静的表示の設定...</h3><p><span class="en">Blosxom</span>は標準で動的にページを作成します（<span class="en">CGI</span>スクリプトとして動作）。静的表示を有効にするには静的なウェブページを保存するためのディレクトリを作成し、静的表示用に<span class="en">Blosxom</span>の設定を行う必要があります。</p>
 <ol>
 <li>
-<p>�ÓI�ȃE�F�u�y�[�W��ۑ����邽�߂ɁA�E�F�u�A�N�Z�X�\�ȃf�B���N�g���̉��̂ǂ����Ƀt�H���_/�f�B���N�g�����쐬���܂��B���̏ꏊ�Ɋւ��Ă����߂��������Ƃ�����܂��F</p>
+<p>静的なウェブページを保存するために、ウェブアクセス可能なディレクトリの下のどこかにフォルダ/ディレクトリを作成します。その場所に関してお勧めしたいことがあります：</p>
 
 <dl>
-<dt><span class="en">ISP</span>�i�v���o�C�_�j</dt>
+<dt><span class="en">ISP</span>（プロバイダ）</dt>
 <dd>
-<p><span class="en">ISP</span>�ɋM���̃E�F�u�f�B���N�g���̃t���p�X��q�˂āA���̉��̂ǂ����ɐÓI�y�[�W��u���f�B���N�g�����쐬���ĉ������B�Ⴆ�΁A <span class="be">/home/sam/www</span> 
-���E�F�u�f�B���N�g���̏ꍇ�ɓK���ȏꏊ�� <span class="be">/home/sam/www/blog</span>�ł��B�R�}���h���C���ő���ł���ꍇ�ɂ͈ȉ��̂悤�ȃR�}���h��<span class="bl">�E�F�u���O</span>�f�B���N�g�����쐬���邱�Ƃ��ł��܂��F</p>
+<p><span class="en">ISP</span>に貴方のウェブディレクトリのフルパスを尋ねて、その下のどこかに静的ページを置くディレクトリを作成して下さい。例えば、 <span class="be">/home/sam/www</span> 
+がウェブディレクトリの場合に適当な場所は <span class="be">/home/sam/www/blog</span>です。コマンドラインで操作できる場合には以下のようなコマンドで<span class="bl">ウェブログ</span>ディレクトリを作成することができます：</p>
 <pre class="en">mkdir /home/sam/www/blog
 chmod -R 755 /home/sam/www/blog
 </pre>
-<p><span class="en">FTP</span>�ڑ������o���Ȃ��ꍇ�ɂ͂��D����FTP�A�v���P�[�V������<span class="bl">�E�F�u���O</span>�f�B���N�g�����쐬���ĉ������B</p>
+<p><span class="en">FTP</span>接続しか出来ない場合にはお好きなFTPアプリケーションで<span class="bl">ウェブログ</span>ディレクトリを作成して下さい。</p>
 </dd>
 
 <dt class="en">Mac OS X</dt>
 <dd>
-<p><span class="be">/Library/WebServer/Documents/blog</span>���Ă��܂��B����<a href="downloads.html"><span class="en">Mac OS X Blosxom</span>�C���X�g�[��</a>���g���Ă���ꍇ�͋M���̐ݒ�Ɉˑ����Ă��܂��B����ȊO�̏ꍇ�ɂ̓^�[�~�i�����N�����Ĉȉ��̂悤�ɓ��͂��܂��F</p>
+<p><span class="be">/Library/WebServer/Documents/blog</span>を提案します。もし<a href="downloads.html"><span class="en">Mac OS X Blosxom</span>インストーラ</a>を使っている場合は貴方の設定に依存しています。それ以外の場合にはターミナルを起動して以下のように入力します：</p>
 <pre class="en">sudo mkdir /Library/WebServer/Documents/blog/
 sudo chmod 755 /Library/WebServer/Documents/blog
 </pre>
 <p>
-�i�p�X���[�h�̓��͂����邩���m��܂���j
+（パスワードの入力があるかも知れません）
 </p>
 </dd>
 
 <dt class="en">Windows 2000/XP</dt>
 <dd>
-<p>�G�N�X�v���[����<span class="be">c:\Inetpub\Blog</span>�ƌ����V�����t�H���_�����܂��B</p>
+<p>エクスプローラで<span class="be">c:\Inetpub\Blog</span>と言う新しいフォルダを作ります。</p>
 </dd>
 </dl>
 </li>
 
 <li>
-<p>�ÓI�\���̐ݒ��<span class="en">Blosxom</span>�̑��̑S�Ă̐ݒ�Ɠ��l�ł��B�X�N���v�g���̂̒��ɂ���܂��B�W���ł͈ȉ��̂悤�ȓ��e�ɂȂ��Ă��܂��F</p>
+<p>静的表示の設定は<span class="en">Blosxom</span>の他の全ての設定と同様です。スクリプト自体の中にあります。標準では以下のような内容になっています：</p>
 <pre class="en"># --- Static Rendering -----
 
 # Where are this blog's static files to be created?
 $static_dir = &quot;/Library/WebServer/Documents/blog&quot;;
 </pre>
 
-<p class="bl">�ÓI�y�[�W�i�t�@�C���j���쐬����ꏊ�B</p>
+<p class="bl">静的ページ（ファイル）を作成する場所。</p>
 
 <pre class="en">
 # What's my administrative password
 # (you must set this for static rendering)?
 $static_password = &quot;&quot;;
 </pre>
-<p class="bl">�Ǘ��җp�p�X���[�h�i�ÓI�\��������ɂ͐ݒ肵�Ȃ��Ă͂Ȃ�Ȃ��j�B</p>
+<p class="bl">管理者用パスワード（静的表示をするには設定しなくてはならない）。</p>
 
 <pre class="en">
 # What flavours should I generate statically?
 @static_flavours = qw/html rss/;
 </pre>
-<p class="bl">�ǂ̃t���[�o�[���g�����B</p>
+<p class="bl">どのフレーバーを使うか。</p>
 
 <pre class="en">
 # Should I statically generate individual entries?
 # 0 = no, 1 = yes
 $static_entries = 0;
 </pre>
-<p>�X�̃G���g����ÓI�ɍ쐬���邩�B</p>
+<p>個々のエントリを静的に作成するか。</p>
 
 <pre>
 # --------------------------------
 </pre>
 </li>
 </ol>
-<p>�e�ݒ�f�B���N�e�B�u�͐ݒ薼�ō\������Ă��܂��i�� <span class="be">$static_dir</span>�A =�L���A�ݒ�l�i��@<span class="be">&quot;/Library/WebServer/Documents/blog&quot;</span>�@�����̏ꍇ��&quot;�ň݂͂܂��B�����̏ꍇ��&quot;�ň݂͂܂���j�B�ݒ�l��ς���ꍇ�ɂ͖]�ޒl�ŒP���ɒu��������Ηǂ��ł��B&quot;���������ꍇ�ɂ͎c���Ēu���ĉ������B</p><p>�Ⴆ�΁A�ÓI�y�[�W��u���ꏊ��W���̏ꏊ����ς���ꍇ�ɂ́i<span class="be">/Library/WebServer/Documents/blog</span>���� <span class="be">/home/username/www/blog</span>�ցj�A���̐ݒ�̍s��<span class="be">$static_dir = &quot;/home/username/www/blog&quot;;</span> �̂悤�ɂȂ�܂��B</p><p>������܂������H�@�ǂ��ł��傤�B�ł͎��ۂ̐ݒ���s���Ă݂܂��傤�F</p>
+<p>各設定ディレクティブは設定名で構成されています（例 <span class="be">$static_dir</span>、 =記号、設定値（例　<span class="be">&quot;/Library/WebServer/Documents/blog&quot;</span>　文字の場合は&quot;で囲みます。数字の場合は&quot;で囲みません）。設定値を変える場合には望む値で単純に置き換えれば良いです。&quot;があった場合には残して置いて下さい。</p><p>例えば、静的ページを置く場所を標準の場所から変える場合には（<span class="be">/Library/WebServer/Documents/blog</span>から <span class="be">/home/username/www/blog</span>へ）、その設定の行は<span class="be">$static_dir = &quot;/home/username/www/blog&quot;;</span> のようになります。</p><p>分かりましたか？　良いでしょう。では実際の設定を行ってみましょう：</p>
 <dl>
 <dt class="bl"><span class="en">$static_dir</span>
 </dt>
 <dd>
-<p>�ÓI�y�[�W��u���ꏊ�ł��B�t���p�X�Ŏw�肵�܂��B</p>
+<p>静的ページを置く場所です。フルパスで指定します。</p>
 
 <dl>
 <dt class="en">ISP</dt>
 <dd>
-<p>�M���̃E�F�u�f�B���N�g���ւ̃t���p�X��<span class="en">ISP</span>�ɖ₢���킹��K�v�����邩���m��܂���B���������炻�̏ꏊ�̉��̂ǂ����� <span class="en">$static_dir</span> �Ɏw�肵�܂��B�Ⴆ�΁A�E�F�u�f�B���N�g���� <span class="be">/home/sam/www</span> �̏ꍇ�ɂ͈ȉ��̂悤�ɂ��܂��F</p>
+<p>貴方のウェブディレクトリへのフルパスを<span class="en">ISP</span>に問い合わせる必要があるかも知れません。分かったらその場所の下のどこかを <span class="en">$static_dir</span> に指定します。例えば、ウェブディレクトリが <span class="be">/home/sam/www</span> の場合には以下のようにします：</p>
 <pre class="en">
 # Where are this blog's static files to be created?
 $static_dir = &quot;/home/sam/www/blog&quot;;
@@ -149,7 +149,7 @@ $static_dir = &quot;/home/sam/www/blog&quot;;
 </dd>
 <dt class="en">Mac OS X</dt>
 <dd>
-<p><span class="en">Mac OS X</span>��<a href="downloads.html">�C���X�g�[��</a>���g����<span class="en">Blosxom</span>���C���X�g�[��������A<a href="doc_users_configure.html">���ƂŃC���X�g�[��</a>�����ꍇ�ɂ��ȉ��̂悤�Ȋ����ɂȂ�܂��F</p>
+<p><span class="en">Mac OS X</span>に<a href="downloads.html">インストーラ</a>を使って<span class="en">Blosxom</span>をインストールしたり、<a href="doc_users_configure.html">手作業でインストール</a>した場合にも以下のような感じになります：</p>
 <pre class="en">
 # Where are this blog's static files to be created?
 $static_dir = &quot;/Library/WebServer/Documents/blog&quot;;
@@ -157,7 +157,7 @@ $static_dir = &quot;/Library/WebServer/Documents/blog&quot;;
 </dd>
 <dt class="en">Windows 2000/XP</dt>
 <dd>
-<p><span class="en">Windows 2000/XP</span>��<span class="en">Blosxom</span>���C���X�g�[�����A<span class="en">IIS</span>���ғ����Ă���ꍇ�� <span class="be">c:\Inetpub</span> �f�B���N�g���̉��̂ǂ������g���܂��B<span class="en">Windows</span>�̓p�X�̋�؂�Ƀo�b�N�X���b�V���i���{��ł́��j���g���܂���<span class="en">Perl</span>�ł̓X���b�V���i/�j���g���܂��F</p>
+<p><span class="en">Windows 2000/XP</span>に<span class="en">Blosxom</span>をインストールし、<span class="en">IIS</span>が稼動している場合は <span class="be">c:\Inetpub</span> ディレクトリの下のどこかを使います。<span class="en">Windows</span>はパスの区切りにバックスラッシュ（日本語では¥）を使いますが<span class="en">Perl</span>ではスラッシュ（/）を使います：</p>
 <pre class="en">
 # Where are this blog's static files to be created?
 $static_dir = &quot;c:/Inetpub/blog&quot;;
@@ -168,22 +168,22 @@ $static_dir = &quot;c:/Inetpub/blog&quot;;
 
 <dt class="bl"><span class="en">$static_password</span></dt>
 <dd>
-<p>�ÓI�\�����[�h�ɂ���ɂ�<span class="en">Blosxom</span>�Ƀp�X���[�h��ݒ肷��K�v������܂��B����͑�O�҂��O����M���̃E�F�u���O��ÓI�\�����Ă��܂����Ƃ���ی삷����̂ł��B <span class="en">Blosxom</span>��<span class="en">CGI</span>�Ƃ��ē��삷�邩�R�}���h���C���œ��삷�邩���m�F���܂����A��������ΗJ���Ȃ��B�ÓI�\���͋�̃p�X���[�h�ł͓��삵�Ȃ��̂Ńp�X���[�h��K���ݒ肷��̂����Y��Ȃ��B</p>
+<p>静的表示モードにするには<span class="en">Blosxom</span>にパスワードを設定する必要があります。これは第三者が外から貴方のウェブログを静的表示してしまうことから保護するものです。 <span class="en">Blosxom</span>は<span class="en">CGI</span>として動作するかコマンドラインで動作するかを確認しますが、備えあれば憂いなし。静的表示は空のパスワードでは動作しないのでパスワードを必ず設定するのをお忘れなく。</p>
 </dd>
 
 <dt class="bl"><span class="en">@static_flavours</span></dt>
 <dd>
-<p>�ÓI�ɕ\������ۂ̃t���[�o�[�̃��X�g�ł��B�W���ł� <span class="en">HTML</span>��<span class="en">RSS</span>�ł��B���Ɏg���Ă���t���[�o�[������ꍇ�ɂ́i�K�؂�<span class="en">head.flavour</span>�A<span class="en">story.flavour</span>�A<span class="en">foot.flavour</span>�A<span class="en">content_type.flavour</span>�t�@�C����<span class="en">$datadir</span>�ɂ���ꍇ�j�A�P�Ƀ��X�g�ɒǉ�����Ηǂ��ł��i�X�y�[�X�ŋ�؂�܂��j�B</p>
+<p>静的に表示する際のフレーバーのリストです。標準では <span class="en">HTML</span>と<span class="en">RSS</span>です。他に使っているフレーバーがある場合には（適切な<span class="en">head.flavour</span>、<span class="en">story.flavour</span>、<span class="en">foot.flavour</span>、<span class="en">content_type.flavour</span>ファイルが<span class="en">$datadir</span>にある場合）、単にリストに追加すれば良いです（スペースで区切ります）。</p>
 </dd>
 
 <dt class="bl"><span class="en">$static_entries</span></dt>
 <dd>
-<p>�ÓI�\���̎��Ƀp�X�x�[�X�A�N���A�����A�����̕\���ɉ����Ċe�G���g���ɑ΂��Čʃt�@�C�����쐬���邩��ݒ肵�܂��B�f�t�H���g��&quot;������&quot;�i0�j�ł��B�Ȃ��Ȃ�M�����撣���đ����̃E�F�u���O�����Ɩc��ȃt�@�C�����쐬�����\�������邽�߂ł��B</p>
+<p>静的表示の時にパスベース、年次、月次、日次の表示に加えて各エントリに対して個別ファイルを作成するかを設定します。デフォルトは&quot;いいえ&quot;（0）です。なぜなら貴方が頑張って多くのウェブログを作ると膨大なファイルが作成される可能性があるためです。</p>
 </dd>
 
 </dl>
-<h3>�E�F�u���O�̕\��...</h3><p>�ÓI�\���̓R�}���h���C���ł̂ݓ��삷��悤�ɐ݌v����Ă��܂��B�E�F�u�T�[�o���ݒ肷����ϐ�<span class="be">GATEWAY_INTERFACE</span>������<span class="en">CGI</span>���ǂ����𔻒f���Ă��܂��B <span class="en">Just in case your server doesn't honour this convention, you need to supply Blosxom with the right password or it'll simply spit out a standard index page dynamically.</span> </p><p><span class="en">Blosxom</span>�̐ÓI�\���𓮍삳����ɂ̓R�}���h���C���ňȉ��̂悤�ɓ��͂��܂��F</p><pre class="en">perl blosxom.cgi -password='whateveryourpassword'</pre><p>�i<span class="be">whateveryourpassword</span>�͐ݒ肵���p�X���[�h�ł��j</p>
-<p><span class="en">Blosxom</span>�̓y�[�W�쐬���J�n���܂��F</p><pre class="en">% perl blosxom.cgi -password='whateveryourpassword'
+<h3>ウェブログの表示...</h3><p>静的表示はコマンドラインでのみ動作するように設計されています。ウェブサーバが設定する環境変数<span class="be">GATEWAY_INTERFACE</span>を見て<span class="en">CGI</span>かどうかを判断しています。 <span class="en">Just in case your server doesn't honour this convention, you need to supply Blosxom with the right password or it'll simply spit out a standard index page dynamically.</span> </p><p><span class="en">Blosxom</span>の静的表示を動作させるにはコマンドラインで以下のように入力します：</p><pre class="en">perl blosxom.cgi -password='whateveryourpassword'</pre><p>（<span class="be">whateveryourpassword</span>は設定したパスワードです）</p>
+<p><span class="en">Blosxom</span>はページ作成を開始します：</p><pre class="en">% perl blosxom.cgi -password='whateveryourpassword'
 Blosxom is generating static index pages...
 /index.html
 /index.rss
@@ -200,20 +200,20 @@ society/film/index.html
 society/film/index.rss
 %
 </pre>
-<p>(�p�X�͂������M���̂Ƃ͈Ⴂ�܂��j</p><p>�ĂыN�����Ă������N����܂���B�Ō�ɋN�����������猻�݂܂łɃE�F�u���O�ɕύX�������������o���邽�߂ł��B</p><pre class="en">
+<p>(パスはもちろん貴方のとは違います）</p><p>再び起動しても何も起こりません。最後に起動した時から現在までにウェブログに変更が無い事を検出するためです。</p><pre class="en">
 % perl blosxom.cgi -password='whateveryourpassword'
 Blosxom is generating static index pages...
 %
-</pre><p>�S�Ẵy�[�W�������I�ɍ쐬����ɂ� <span class="be">-all=1</span> �X�C�b�`���w�肵�܂��F</p><pre class="en">
+</pre><p>全てのページを強制的に作成するには <span class="be">-all=1</span> スイッチを指定します：</p><pre class="en">
 % perl blosxom.cgi -password='whateveryourpassword' -all=1
-</pre><p><span class="en">Blosxom</span>�̓E�F�u���O�ɕύX�����邩�ǂ����ɂ�����炸�A�ēx�S�Ẵy�[�W���쐬���܂��B</p><p>�y�[�W�̍쐬���T�C�����g���[�h�ōs���ɂ� --����I��<a href="#automatic">����</a>�ō쐬���Ă���̂Ō��ʂ��\�������K�v�͖����A���[���ŕ񍐂����--  <span class="be">-quiet=1</span> �X�C�b�`���g���܂��F</p><pre class="en">
+</pre><p><span class="en">Blosxom</span>はウェブログに変更があるかどうかにかかわらず、再度全てのページを作成します。</p><p>ページの作成をサイレントモードで行うには --定期的に<a href="#automatic">自動</a>で作成しているので結果が表示される必要は無い、メールで報告される--  <span class="be">-quiet=1</span> スイッチを使います：</p><pre class="en">
 % perl blosxom.cgi -password='whateveryourpassword' -quiet=1
 </pre>
 
-<h3><a name="automatic" class="anc">����I�Ɏ����Ńy�[�W���쐬����...</a></h3><p>�V�����E�F�u���O���쐬�����炢�ł��R�}���h���C���ŐÓI�y�[�W���쐬�ł��܂����A�����I�ɍs���ė~������������ł��傤�B</p><p><span class="en">Unix</span>�n��<span class="en">Mac OS X</span>���g���Ă���ꍇ�ɂ͍�Ƃ̎������� <span class="en">cron</span> �Ƃ����c�[�����g���܂��B����͓������Ƃ�����Ƃ��ɒ���I�ɍs���Ă����c�[���ł��B<span class="en">cron</span>�̃}�j���A�������ĉ������i�R�}���h���C����<span class="be">man cron</span>�Ɠ��́j�B����Ƒf���炵��<a href="http://www.onlamp.com/pub/a/bsd/2000/09/27/FreeBSD_Basics.html">�`���[�g���A��</a>���B�ȉ���30�����ƂɃy�[�W���쐬����<span class="be">cron</span>�̐ݒ����Љ�܂��F</p><pre class="en">
+<h3><a name="automatic" class="anc">定期的に自動でページを作成する...</a></h3><p>新しいウェブログを作成したらいつでもコマンドラインで静的ページを作成できますが、自動的に行って欲しい時もあるでしょう。</p><p><span class="en">Unix</span>系や<span class="en">Mac OS X</span>を使っている場合には作業の自動化に <span class="en">cron</span> というツールが使えます。これは同じことをあるときに定期的に行ってくれるツールです。<span class="en">cron</span>のマニュアルを見て下さい（コマンドラインで<span class="be">man cron</span>と入力）。それと素晴らしい<a href="http://www.onlamp.com/pub/a/bsd/2000/09/27/FreeBSD_Basics.html">チュートリアル</a>も。以下に30分ごとにページを作成する<span class="be">cron</span>の設定例を紹介します：</p><pre class="en">
 0,30 * * * * /usr/bin/perl /path/to/blosxom.cgi
 -password='whateveryourpassword' -quiet=1
-</pre><p>�i�\���̊֌W��2�s�ɕ�����Ă��܂����A<span class="en">crontab</span>�ɂ�1�s�ŏ������Ƃɒ��ӂ��ĉ������j</p><p><span class="be">cron</span>������<span class="en">OS</span>�̏ꍇ�̂��߂�<span class="en">FAQ</span>�ł͑�֕��@���ȒP�ɏЉ�Ă��܂��B�����񋟂ł����񂪂���ꍇ�ɂ͂��Ћ����ĉ������B</p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</pre><p>（表示の関係で2行に分かれていますが、<span class="en">crontab</span>には1行で書くことに注意して下さい）</p><p><span class="be">cron</span>が無い<span class="en">OS</span>の場合のために<span class="en">FAQ</span>では代替方法を簡単に紹介しています。何か提供できる情報がある場合にはぜひ教えて下さい。</p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_configure_static.html
+++ b/doc_users_configure_static.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::静的表示</title>
 

--- a/doc_users_flavour.html
+++ b/doc_users_flavour.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::フレーバー（Flavour）</title>
 

--- a/doc_users_flavour.html
+++ b/doc_users_flavour.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�t���[�o�[�iFlavour�j</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::フレーバー（Flavour）</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,126 +11,126 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�t���[�o�[�i<span class="be">Flavour</span>�j</a></h1><h2>�t���[�o�[</h2><p><span class="en">Blosxom</span>��2�̃t���[�o�[��\�ߒ񋟂��Ă��܂��B��{�̃f�t�H���g <span class="en">HTML</span>��<span class="en">XML</span>�x�[�X��<a href="doc_users_syndicate.html">�V���W�P�[�g</a>�̂��߂�<span class="en">RSS</span>�ł��B</p><p>���͂܂��A<span class="en">Blosxom Flavour Sampler</span>�i�t���[�o�[�̃T���v���j���쐬���܂����B����̃t���[�o�[�e���v���[�g�ō\�����ꂽ���̂ł��i�����ɂ��b���܂��j�B</p><p>�W����<span class="en">HTML</span>�͊ȒP�ɕύX�ł��܂��B<span class="en">earth-shatteringly</span>�ȉ��₩�Ȕ����w�i�ɑ傫�ȕ����̑薼�B�L���͋@�\�I�ł�����͂菭�����₩�Ȋ����ł��F</p><p class="en">
+<td id="contents"><h1><a name="top" class="bl">フレーバー（<span class="be">Flavour</span>）</a></h1><h2>フレーバー</h2><p><span class="en">Blosxom</span>は2つのフレーバーを予め提供しています。基本のデフォルト <span class="en">HTML</span>と<span class="en">XML</span>ベースの<a href="doc_users_syndicate.html">シンジケート</a>のための<span class="en">RSS</span>です。</p><p>私はまた、<span class="en">Blosxom Flavour Sampler</span>（フレーバーのサンプル）を作成しました。幾つかのフレーバーテンプレートで構成されたものです（じきにお話します）。</p><p>標準の<span class="en">HTML</span>は簡単に変更できます。<span class="en">earth-shatteringly</span>な穏やかな白い背景に大きな文字の題名。記事は機能的ですがやはり少し穏やかな感じです：</p><p class="en">
 <strong>Typical Post</strong><br>
 Your typical <span class="undl">Blosxom</span> post consists of a required title<br>
 on the first line and any manner of text and HTML<br>
 markup in the body.<br>
 <br>
 posted at: 11:33 | path: <span class="undl">/</span> | <span class="undl">permanent link to this entry</span>
-</p><p>���肪�������ƂɁA�č\������͔̂��ɒP���ł��B�o���邱�Ƃ�2��������܂���F�e���v���[�g�R���|�[�l���g�ƃe���v���[�g�t�@�C���ł��B</p><h3>�e���v���[�g�R���|�[�l���g...</h3><p>�e���v���[�g�R���|�[�l���g��<span class="en">Blosxom</span>�œ��I�ɍ쐬�����R���e���c�̗v�f�ł��B<span class="be">$blog_title</span>�́A�Ⴆ�΁A<a href="doc_users_configure.html">�ݒ�</a>�ŃZ�b�g����E�F�u���O�̃^�C�g�������Ă����Ƃ���ł��B�t���[�o�[�e���v���[�g�̂ǂ��ł��A���ꂪ������Ɠ��I�ɐݒ肵���l�ɒu��������ĕ\������܂��B</p><p>�e���v���[�g�R���|�[�l���g��2�̎�ނ�����܂��F�O���[�o���ƃX�g�[���[�ł��B</p><h3><a name="globaltemplatecomponent" class="anc">...�O���[�o���e���v���[�g�R���|�[�l���g</a></h3><p>�O���[�o���R���|�[�l���g�̓e���v���[�g�t�@�C���̂ǂ��ł��g�p�ł��܂��B��������<span class="en">Blosxom</span>��<a href="doc_users_configure.html">�ݒ�</a>�ŃZ�b�g���A���͓��I�ɐ�������܂��B</p><dl>
+</p><p>ありがたいことに、再構成するのは非常に単純です。覚えることは2つしかありません：テンプレートコンポーネントとテンプレートファイルです。</p><h3>テンプレートコンポーネント...</h3><p>テンプレートコンポーネントは<span class="en">Blosxom</span>で動的に作成されるコンテンツの要素です。<span class="be">$blog_title</span>は、例えば、<a href="doc_users_configure.html">設定</a>でセットするウェブログのタイトルを入れておくところです。フレーバーテンプレートのどこでも、それが現われると動的に設定した値に置き換わって表示されます。</p><p>テンプレートコンポーネントは2つの種類があります：グローバルとストーリーです。</p><h3><a name="globaltemplatecomponent" class="anc">...グローバルテンプレートコンポーネント</a></h3><p>グローバルコンポーネントはテンプレートファイルのどこでも使用できます。いくつかは<span class="en">Blosxom</span>の<a href="doc_users_configure.html">設定</a>でセットし、他は動的に生成されます。</p><dl>
 <dt class="bl"><span class="en">$blog_title</span></dt>
 <dd>
-<p>�E�F�u���O�̃^�C�g���ŁA<span class="en">Blosxom</span>�̐ݒ�Ŏw�肵�܂��B<br>
-�� <span class="en">My Blosxom Blog</span></p>
+<p>ウェブログのタイトルで、<span class="en">Blosxom</span>の設定で指定します。<br>
+例 <span class="en">My Blosxom Blog</span></p>
 </dd>
 <dt class="bl"><span class="en">$blog_description</span></dt>
 <dd>
-<p>�E�F�u���O�̐����ŁA<span class="en">Blosxom</span>�̐ݒ�Ŏw�肵�܂��B<br>
-�� <span class="en">A blog about this and that.</span></p>
+<p>ウェブログの説明で、<span class="en">Blosxom</span>の設定で指定します。<br>
+例 <span class="en">A blog about this and that.</span></p>
 </dd>
 <dt class="bl"><span class="en">$blog_language</span></dt>
 <dd>
-<p>����R�[�h�ŁA<span class="en">Blosxom</span>�̐ݒ�Ŏw�肵�܂��B<br>
-�� <span class="en">en-us</span></p>
+<p>言語コードで、<span class="en">Blosxom</span>の設定で指定します。<br>
+例 <span class="en">en-us</span></p>
 </dd>
 <dt class="bl"><span class="en">$url</span></dt>
 <dd>
-<p>�E�F�u���O��<span class="en">URL</span>�B<span class="en">Blosxom</span>�Ŏ������ʂ���܂����A<span class="en">Blosxom</span>�̐ݒ�Ŏw����ł��܂��B<br>
-�� <span class="en">http://www.example.com/cgi-bin/blosxom.cgi</span></p>
+<p>ウェブログの<span class="en">URL</span>。<span class="en">Blosxom</span>で自動判別されますが、<span class="en">Blosxom</span>の設定で指定もできます。<br>
+例 <span class="en">http://www.example.com/cgi-bin/blosxom.cgi</span></p>
 </dd>
 <dt class="bl"><span class="en">$path_info</span></dt>
 <dd>
-<p>�ŏ���<a href="doc_users_view.html">�{��</a>�L�����w�肵�܂��B�p�X�A���t�A�����̑g�ݍ��킹�Ŏw�肵�܂��B<br>
-�� <span class="en">/society/television/retro/1977/</span> </p>
+<p>最初の<a href="doc_users_view.html">閲覧</a>記事を指定します。パス、日付、それらの組み合わせで指定します。<br>
+例 <span class="en">/society/television/retro/1977/</span> </p>
 </dd>
 <dt class="bl"><span class="en">$flavour</span></dt>
 <dd>
-<p>�g�p����t���[�o�[�B<br>
-�� <span class="en">http://www.excampe.com/cgi-bin/blosxom.cgi/index.someflavour</span></p>
+<p>使用するフレーバー。<br>
+例 <span class="en">http://www.excampe.com/cgi-bin/blosxom.cgi/index.someflavour</span></p>
 </dd>
-</dl><h3>...�X�g�[���[�e���v���[�g�R���|�[�l���g</h3><p>�X�g�[���[�R���|�[�l���g�͋L���i���O�j�ɂ���ĕω����܂��B</p><dl>
+</dl><h3>...ストーリーテンプレートコンポーネント</h3><p>ストーリーコンポーネントは記事（ログ）によって変化します。</p><dl>
 <dt class="bl"><span class="en">$title</span></dt>
 <dd>
-<p>�L���̃^�C�g���B<br>
-�� <span class="en">Typical Post</span></p>
+<p>記事のタイトル。<br>
+例 <span class="en">Typical Post</span></p>
 </dd>
 <dt class="bl"><span class="en">$body</span></dt>
 <dd>
-<p>�L���̖{�� --�t�@�C���̍ŏ��̍s�ȊO�̑S���B<br>
-�� <span class="en">Your typical ... in the body.</span> </p>
+<p>記事の本文 --ファイルの最初の行以外の全部。<br>
+例 <span class="en">Your typical ... in the body.</span> </p>
 </dd>
 <dt class="bl"><span class="en">$url</span></dt>
 <dd>
-<p>�E�F�u���O��<span class="en">URL</span>�B<span class="en">Blosxom</span>�Ŏ������ʂ���܂����A<span class="en">Blosxom</span>�̐ݒ�Ŏw����ł��܂��B����͎��ۂ̓O���[�o���e���v���[�g�R���|�[�l���g�ł����A�L���ւ�<span class="en">permalink</span>���쐬����̂ɕ֗��Ȃ̂ł����ł��Љ�܂����B<br>
-�� <span class="en">http://www.example.com/cgi-bin/blosxom.cgi</span></p>
+<p>ウェブログの<span class="en">URL</span>。<span class="en">Blosxom</span>で自動判別されますが、<span class="en">Blosxom</span>の設定で指定もできます。これは実際はグローバルテンプレートコンポーネントですが、記事への<span class="en">permalink</span>を作成するのに便利なのでここでも紹介しました。<br>
+例 <span class="en">http://www.example.com/cgi-bin/blosxom.cgi</span></p>
 </dd>
 <dt class="bl"><span class="en">$path</span></dt>
 <dd>
-<p>������E�F�u���O�̃f�B���N�g��/�t�H���_�K�w�̒���<a href="doc_users_configure.html">�p�X</a>�B<br>
-�� <span class="en">travel/india</span></p>
+<p>今いるウェブログのディレクトリ/フォルダ階層の中の<a href="doc_users_configure.html">パス</a>。<br>
+例 <span class="en">travel/india</span></p>
 </dd>
 <dt class="bl"><span class="en">$yr, $mo, $mo_num, $da, $hr, $min</span></dt>
 <dd>
-<p>�L���������ꂽ���t/���ԁB������A�N�A�� <span class="bl">(</span><span class="be">Jan-Dec</span>)�A�� (<span class="be">01-12</span>)�A�� (<span class="be">01-31</span>)�A�� (<span class="be">00-23</span>)�A�� (<span class="be">00-59</span>)�B <br>
-�� <span class="en">2002, &quot;Dec&quot;, 12, 01, 11, 33</span></p>
+<p>記事が書かれた日付/時間。左から、年、月 <span class="bl">(</span><span class="be">Jan-Dec</span>)、月 (<span class="be">01-12</span>)、日 (<span class="be">01-31</span>)、時 (<span class="be">00-23</span>)、分 (<span class="be">00-59</span>)。 <br>
+例 <span class="en">2002, &quot;Dec&quot;, 12, 01, 11, 33</span></p>
 </dd>
 <dt class="bl"><span class="en">$fn</span></dt>
 <dd>
-<p>�L���̃t�@�C�����B�g���q�i<span class="be">.txt</span>�j�͏ȗ����܂��B<br>
-�� <span class="en">typical_post</span></p>
+<p>記事のファイル名。拡張子（<span class="be">.txt</span>）は省略します。<br>
+例 <span class="en">typical_post</span></p>
 </dd>
-</dl><p>�T���v����<span class="en">HTML</span>�t���[�o�[�ɍs���ƁA�i�ނɂ�đ召���낢��Ȃ��Ƃ��Љ��܂��B�����̃t�@�C���͂܂�����܂���B�f�t�H���g��<span class="en">HTML</span>�̓r���g�C���ł��i<span class="be">blosxom.cgi</span>���̂ɏ�����Ă��܂��j�B�V����<span class="en">HTML</span>�����Ƃ��̃f�t�H���g�o�[�W�����̑���Ɏg���܂��B</p><h3>�e���v���[�g�t�@�C��...</h3><p> <span class="en">Blosxom</span>�̃e���v���[�g�͎��̂��̂ō\������Ă��܂��B </p><p><span class="en">head</span> (�L���̑O�j�A<span class="en">foot</span> (�L���̌�j�A<span class="en">story</span> (�L�����Ƃ̏����j�A<span class="en">content_type</span> (����̃t���[�o�[�̃R���e���c�^�C�v�j�A<span class="en">date</span>�i�^�C���X�^���v�̌����ڂ𑀍�B�I�v�V�����j�B</p><p>�����͎��̖��O�����t�@�C���Ƃ��đ��݂��܂��F<span class="en">head</span>�A<span class="en">foot</span>�A<span class="en">story</span>�A<span class="en">content_type</span>�A<span class="en">date</span></p><p>������<span class="en">Blosxom</span>�ł�1�ȏ�̃t���[�o�[���g����̂ŉ��炩�̕��@�ŕ\�����Ȃ��Ă͂Ȃ�܂���B<span class="en">HTML</span>�t���[�o�[�Ɋւ��Ă͎��̂悤�ɂ��܂��F<br>
-<span class="be">head.html, foot.html, story.html, content_type.html, date.html</span></p><p>�ȒP�ł��傤�H</p><h3>...�w�b�_</h3><p>�w�b�_�͋L���̑O�ɑS�ĕ\������܂��B<span class="en">HTML</span>�t���[�o�[�ɑ΂���w�b�_��<a href="doc_users_configure.html">�f�[�^�f�B���N�g��</a>����<span class="be">head.html</span>�ƌ����t�@�C���ɂȂ�܂��B</p><p><span class="en">head.html</span>�̃T���v���ł��F</p><pre class="en">&lt;html&gt;
+</dl><p>サンプルの<span class="en">HTML</span>フレーバーに行くと、進むにつれて大小いろいろなことが紹介されます。これらのファイルはまだありません。デフォルトの<span class="en">HTML</span>はビルトインです（<span class="be">blosxom.cgi</span>自体に書かれています）。新しい<span class="en">HTML</span>を作るとこのデフォルトバージョンの代わりに使われます。</p><h3>テンプレートファイル...</h3><p> <span class="en">Blosxom</span>のテンプレートは次のもので構成されています。 </p><p><span class="en">head</span> (記事の前）、<span class="en">foot</span> (記事の後）、<span class="en">story</span> (記事ごとの書式）、<span class="en">content_type</span> (特定のフレーバーのコンテンツタイプ）、<span class="en">date</span>（タイムスタンプの見た目を操作。オプション）。</p><p>これらは次の名前を持つファイルとして存在します：<span class="en">head</span>、<span class="en">foot</span>、<span class="en">story</span>、<span class="en">content_type</span>、<span class="en">date</span></p><p>しかし<span class="en">Blosxom</span>では1つ以上のフレーバーが使えるので何らかの方法で表現しなくてはなりません。<span class="en">HTML</span>フレーバーに関しては次のようにします：<br>
+<span class="be">head.html, foot.html, story.html, content_type.html, date.html</span></p><p>簡単でしょう？</p><h3>...ヘッダ</h3><p>ヘッダは記事の前に全て表示されます。<span class="en">HTML</span>フレーバーに対するヘッダは<a href="doc_users_configure.html">データディレクトリ</a>内の<span class="be">head.html</span>と言うファイルになります。</p><p><span class="en">head.html</span>のサンプルです：</p><pre class="en">&lt;html&gt;
 &lt;head&gt;
  &lt;title&gt;$blog_title&lt;/title&gt;
 &lt;/head&gt;
@@ -138,14 +138,14 @@ posted at: 11:33 | path: <span class="undl">/</span> | <span class="undl">perman
 &lt;b&gt;$blog_title&lt;/b&gt;
 &lt;hr size=&quot;1&quot; noshade /&gt;
 &lt;p /&gt;
-</pre><p>�D���ȃe�L�X�g�G�f�B�^�ł���<span class="en">HTML</span>���R�s�[���y�[�X�g����<span class="be">datadir/head.html</span>�Ƀe�L�X�g�t�@�C���Ƃ��ĕۑ����ĉ������B<span class="be">datadir</span>��<span class="en">Blosxom</span>��<a href="doc_users_configure.html">�f�[�^�f�B���N�g��</a>�ł��B</p><p><span class="be">$blog_title</span>���ĉ��H�@<a href="#globaltemplatecomponent">�O���[�o���e���v���[�g�R���|�[�l���g</a>�̈�ŁA���̃y�[�W�̂����Ə�Ő������Ă��܂��B</p><h3>...�t�b�^</h3><p>�w�b�_���L���̑O�ɏo������̂Ƃ͑ΏƓI�Ƀt�b�^�͋L���̌�ɏo�����܂��B<span class="en">HTML</span>�t���[�o�[�ɑ΂���t�b�^��<a href="doc_users_configure.html">�f�[�^�f�B���N�g��</a>��<span class="be">foot.html</span>�ƌ����t�@�C�����Œu���܂��B</p><p><span class="be">foot.html</span>�̃T���v���ł��B��������<span class="en">&quot;powered by blosxom&quot;</span>�{�^��������܂��F</p><pre class="en">&lt;p /&gt;
+</pre><p>好きなテキストエディタでこの<span class="en">HTML</span>をコピー＆ペーストして<span class="be">datadir/head.html</span>にテキストファイルとして保存して下さい。<span class="be">datadir</span>は<span class="en">Blosxom</span>の<a href="doc_users_configure.html">データディレクトリ</a>です。</p><p><span class="be">$blog_title</span>って何？　<a href="#globaltemplatecomponent">グローバルテンプレートコンポーネント</a>の一つで、このページのずっと上で説明しています。</p><h3>...フッタ</h3><p>ヘッダが記事の前に出現するのとは対照的にフッタは記事の後に出現します。<span class="en">HTML</span>フレーバーに対するフッタは<a href="doc_users_configure.html">データディレクトリ</a>で<span class="be">foot.html</span>と言うファイル名で置きます。</p><p><span class="be">foot.html</span>のサンプルです。水平線と<span class="en">&quot;powered by blosxom&quot;</span>ボタンがあります：</p><pre class="en">&lt;p /&gt;
 &lt;hr size=&quot;1&quot; noshade /&gt;
 &lt;a href=&quot;http://www.blosxom.com/&quot;&gt;&lt;img
 src=&quot;http://www.raelity.org/images/pb_blosxom.gif&quot;
 border=&quot;0&quot; /&gt;&lt;/a&gt;
 &lt;/body&gt;
 &lt;/html&gt;
-</pre><p>�e�L�X�g�G�f�B�^�ŃR�s�[���y�[�X�g���A<span class="be">datadir/foot.html</span>�Ƀe�L�X�g�t�@�C���Ƃ��ĕۑ����ĉ������B</p><p><span class="en">Blosxom</span>�y�[�W���ēǂݍ��݂���ƕω��ɋC�t���ł��傤�B</p><p>�M���̃y�[�W��<span class="en">&quot;powered by blosxom&quot;</span>�{�^����t���Ȃ��Ă͂Ȃ�Ȃ��Ƃ͂ǂ��ɂ�������Ă��܂��񂪁A�M����<span class="en">Blosxom</span>���[�U�ł���ƌ������Ƃ�m���Ă��炢�A�E�F�u���O���n�߂����Ǝv���Ă���l��<span class="en">Blosxom</span>�ɓ����̂ɂ��ǂ����@�ł��B</p><h3>...�X�g�[���[</h3><p>�L���̕��͂̌����ڂ�<a href="doc_users_configure.html">�f�[�^�f�B���N�g��</a>��<span class="be">story.html</span>�ƌ����e���v���[�g�Ō��܂�܂��B�f�t�H���g�̃��C�A�E�g��������Ƃ����Ă݂ăX�g�[���[�e���v���[�g�R���|�[�l���g���g���Ă݂܂��񂩁H</p><pre class="en">&lt;p&gt;
+</pre><p>テキストエディタでコピー＆ペーストし、<span class="be">datadir/foot.html</span>にテキストファイルとして保存して下さい。</p><p><span class="en">Blosxom</span>ページを再読み込みすると変化に気付くでしょう。</p><p>貴方のページに<span class="en">&quot;powered by blosxom&quot;</span>ボタンを付けなくてはならないとはどこにも書かれていませんが、貴方が<span class="en">Blosxom</span>ユーザであると言うことを知ってもらい、ウェブログを始めたいと思っている人を<span class="en">Blosxom</span>に導くのにも良い方法です。</p><h3>...ストーリー</h3><p>記事の文章の見た目は<a href="doc_users_configure.html">データディレクトリ</a>の<span class="be">story.html</span>と言うテンプレートで決まります。デフォルトのレイアウトをちょっといじてみてストーリーテンプレートコンポーネントを使ってみませんか？</p><pre class="en">&lt;p&gt;
 &lt;a name=&quot;$fn&quot;&gt;&lt;b&gt;$title&lt;/b&gt;&lt;/a&gt;
 &lt;br /&gt;
 $body
@@ -154,24 +154,24 @@ $body
 &lt;i&gt;[&lt;a href=&quot;$url$path&quot;&gt;$path&lt;/a&gt;]
 &lt;a href=&quot;$url/$yr/$mo_num/$da#$fn&quot;&gt;permanent link&lt;/a&gt;&lt;/i&gt;
 &lt;/p&gt;
-</pre><h3>...�X�g�[���[ ...<span class="en">permalinks</span></h3><p>�p�[�}�l���g�����N<span class="en">&quot;permalinks&quot;</span>�B <span class="en">permalink</span>�͋L���̈�ւ̎Q�Ƃ̍ۂɎg����A�����ĕύX�����������񑩂��ꂽ�P�v�I��<span class="en">URL</span>��񋟂�����̂ł��B�E�F�u���O�̃z�[���y�[�W�̉��[����L���������Ă��܂����ꍇ --�v���o���ĉ������A���t���ɕ\������܂�-- <span class="en">permalink</span>�̓����N���΂�΂�ɂȂ������Ԃƃe���v���[�g�ɋt�炤����ۏ؂�����̂ł��B</p><p><span class="en">Blosxom</span>�̕W����<span class="en">permalink</span>�͓��t����ɂ��Ă��܂��i��Ŏ����Ă��܂��j�B�Ⴆ��2003�N2��1����<span class="be">a_story.txt</span>�Ƃ��ĕۑ������L����<br>
+</pre><h3>...ストーリー ...<span class="en">permalinks</span></h3><p>パーマネントリンク<span class="en">&quot;permalinks&quot;</span>。 <span class="en">permalink</span>は記事の一つへの参照の際に使われる、決して変更が無い事が約束された恒久的な<span class="en">URL</span>を提供するものです。ウェブログのホームページの下端から記事が落ちてしまった場合 --思い出して下さい、日付順に表示されます-- <span class="en">permalink</span>はリンクがばらばらになった時間とテンプレートに逆らう事を保証するものです。</p><p><span class="en">Blosxom</span>の標準の<span class="en">permalink</span>は日付を基準にしています（上で示しています）。例えば2003年2月1日に<span class="be">a_story.txt</span>として保存した記事は<br>
 <span class="be">http://www.example.com/cgi-bin/blosxom.cgi/2003/01/01#a_story</span><span class="bl"><br>
-</span>�Ƃ��čP�v�I�Ƀ����N����܂��B����ɂ���Ă��̓��t�̋L���Ƃ��Ē��ڃu���E�U�ł��̋L�����{���ł��܂��i<span class="be">#a_story</span>�j�B������s���ɂ̓e���v���[�g�Ŏ��̂悤�Ȋ����̂��̂��܂߂�悤�ɂ��܂��F<br>
-<span class="be">&lt;a href=&quot;$url/$yr/$mo_num/$da#$fn&quot;&gt;permanent link&lt;/a&gt; </span></p><p><a href="doc_users_configure.html">�p�X</a>����ɂ���<span class="en">permalink</span>��]�ނ����m��܂���B<span class="be">datadir/fiction</span>��<span class="be">a_story.txt</span>�Ƃ��ĕۑ������L����<br>
+</span>として恒久的にリンクされます。これによってその日付の記事として直接ブラウザでその記事を閲覧できます（<span class="be">#a_story</span>）。これを行うにはテンプレートで次のような感じのものを含めるようにします：<br>
+<span class="be">&lt;a href=&quot;$url/$yr/$mo_num/$da#$fn&quot;&gt;permanent link&lt;/a&gt; </span></p><p><a href="doc_users_configure.html">パス</a>を基準にした<span class="en">permalink</span>を望むかも知れません。<span class="be">datadir/fiction</span>に<span class="be">a_story.txt</span>として保存した記事は<br>
  <span class="be">http://www.example.com/cgi-bin/blosxom.cgi/fiction#a_story.txt</span><span class="bl"><br>
-</span>�Ƃ��ă����N����܂��B���̃^�C�v��<span class="en">permalink</span>�̓e���v���[�g�Ŏ��̂悤�Ȋ����ɂ��܂��F<br>
-<span class="be">&lt;a href=&quot;$url$path/index.$flavour#$fn&quot;&gt;permanent link&lt;/a&gt; </span></p><p><span class="en">permalink</span>�ŋL�����ƂɌ����ڂ�ς��邱�Ƃ��ł��܂��B����̓p�X���<span class="en">permalink</span>���C�����܂��F<br>
-<span class="be">&lt;a href=&quot;$url$path/$fn.$flavour&quot;&gt;permanent link&lt;/a&gt; </span></p><h3>...<span class="be">content-type</span></h3><p>�W����<span class="en">content-type</span>�G���R�[�f�B���O --  <span class="en">Blosxom</span>���u���E�U�ɏo�͂̃^�C�v��m�点����̂ł�-- �̓v���[���e�L�X�g�ł��i<span class="en">text/plain</span>�j�B�قȂ�G���R�[�f�B���O�i<span class="be">text/xml</span> ��<span class="be">text/html</span>���j�̃e���v���[�g���쐬�������Ƃ��̓G���R�[�f�B���O���w�肷��<span class="be">content_type.flavour</span>�t�@�C���i<span class="be">flavour</span>�͋M���̎g���t���[�o�[�j���쐬���Ȃ��Ă͂Ȃ�܂���B</p><p>��X�̗�ł́i<span class="en">HTML</span>�t���[�o�[�j�A<span class="en">content-type</span>��<span class="be">text/html</span>�Ńu���E�U�ɂ�<span class="en">HTML</span>�h�L�������g�Ɖ��߂���܂��B</p><p>�e�L�X�g�G�f�B�^�ňȉ����R�s�[���y�[�X�g����<span class="be">datadir/content_type.html</span>�Ƀe�L�X�g�t�@�C���Ƃ��ĕۑ����ĉ������B</p><pre class="en">
+</span>としてリンクされます。このタイプの<span class="en">permalink</span>はテンプレートで次のような感じにします：<br>
+<span class="be">&lt;a href=&quot;$url$path/index.$flavour#$fn&quot;&gt;permanent link&lt;/a&gt; </span></p><p><span class="en">permalink</span>で記事ごとに見た目を変えることもできます。これはパス基準の<span class="en">permalink</span>を修正します：<br>
+<span class="be">&lt;a href=&quot;$url$path/$fn.$flavour&quot;&gt;permanent link&lt;/a&gt; </span></p><h3>...<span class="be">content-type</span></h3><p>標準の<span class="en">content-type</span>エンコーディング --  <span class="en">Blosxom</span>がブラウザに出力のタイプを知らせるものです-- はプレーンテキストです（<span class="en">text/plain</span>）。異なるエンコーディング（<span class="be">text/xml</span> や<span class="be">text/html</span>等）のテンプレートを作成したいときはエンコーディングを指定する<span class="be">content_type.flavour</span>ファイル（<span class="be">flavour</span>は貴方の使うフレーバー）を作成しなくてはなりません。</p><p>我々の例では（<span class="en">HTML</span>フレーバー）、<span class="en">content-type</span>は<span class="be">text/html</span>でブラウザには<span class="en">HTML</span>ドキュメントと解釈されます。</p><p>テキストエディタで以下をコピー＆ペーストして<span class="be">datadir/content_type.html</span>にテキストファイルとして保存して下さい。</p><pre class="en">
 text/html
-</pre><p>�Ⴆ�΁A<span class="en">&quot;exemel&quot;</span>�ƌ����E�F�u���O�ɑ΂���<span class="en">XML</span>�t���[�o�[���쐬�������ɂ�<span class="en">content-type</span>��<span class="en">text/xml</span>�ɂȂ�܂��B���̏ꍇ�A���̈�s������<span class="en">datadir/content_type.exemel</span>�t�@�C�����쐬���܂��F</p><pre class="en">
+</pre><p>例えば、<span class="en">&quot;exemel&quot;</span>と言うウェブログに対して<span class="en">XML</span>フレーバーを作成した時には<span class="en">content-type</span>は<span class="en">text/xml</span>になります。この場合、次の一行を持つ<span class="en">datadir/content_type.exemel</span>ファイルを作成します：</p><pre class="en">
 text/xml
-</pre><h3>...���t</h3><p>�e�L���ɂ͓��t�̃X�^���v������܂��B�ȉ��͕W���̌����ڂł��F</p><pre class="en">
+</pre><h3>...日付</h3><p>各記事には日付のスタンプがあります。以下は標準の見た目です：</p><pre class="en">
 Wednesday, 01 Jan 2003
-</pre><p>���ꂪ�M���̍D�݂ɍ����̂ł����<span class="be">date.html</span>�e���v���[�g�t�@�C���̍쐬�͓ǂݔ�΂��č\���܂���B�����łȂ���Ύ��ɐi��œ��t�Ɋւ���e���v���[�g�R���|�[�l���g���g���ĕύX���܂��F</p><pre class="en">
+</pre><p>これが貴方の好みに合うのであれば<span class="be">date.html</span>テンプレートファイルの作成は読み飛ばして構いません。そうでなければ次に進んで日付に関するテンプレートコンポーネントを使って変更します：</p><pre class="en">
 $yr, $mo, $mo_num, $da, $hr, $min
-</pre><p>����������ƁA�Α̂̐�����<span class="en">HTML</span>�t���[�o�[�Ŏg�����������m��܂���B�ȉ���<span class="en">HTML</span>���e�L�X�g�G�f�B�^�ŃR�s�[���y�[�X�g����<span class="be">datadir/date.html</span>�ƌ����e�L�X�g�t�@�C���ŕۑ����ĉ������B</p><pre class="en">
+</pre><p>もしかすると、斜体の数字を<span class="en">HTML</span>フレーバーで使いたいかも知れません。以下の<span class="en">HTML</span>をテキストエディタでコピー＆ペーストして<span class="be">datadir/date.html</span>と言うテキストファイルで保存して下さい。</p><pre class="en">
 &lt;i&gt;$mo_num/$da/$yr&lt;/i&gt;
-</pre><p>�ȉ��̂悤�ɕ\������܂��F</p><p class="it">01/01/2003</p><p>�e���v���[�g�t�@�C�����ǂ��ɕۑ����邩�Ƃ��ǂ̃e���v���[�g�R���|�[�l���g�����R�ɑg�ݍ��킹�ĂƂ��m���Ă���̂͂��Ă����A����ł͋�͗L���ł��鎖�ɈႢ����܂���B<span class="en">CSS</span>�A<span class="en">JavaScript</span>�A<span class="en">XML</span>�A�v���[���e�L�X�g...���g���ăK�c�K�c�����܂��傤�B�M���̃E�F�u���O�ł��B�D���Ȃ悤�ɍ��܂��傤�B</p><h3>��������̃t���[�o�[...</h3><p>�܂��킫���ɓ���킯�ɂ͍s���܂���B�t���[�o�[�ɕt���Ēm���Ă����ׂ����Ƃ����ɂ�������Ƃ���̂ł�... ��������̃t���[�o�[�B����͋M���̋����Ƒn�����݂̂ɐ����������܂��B <span class="en">HTML</span>�t���[�o�[��<span class="en">RSS</span>�t���[�o�[�͊���&quot;��&quot;�ɓ����Ă��܂����A<span class="be">head.flavour, foot.flavour, story.flavour, content_type.flavour, date.flavour</span>�i�I�v�V�����j�ƌ����t�@�C�������΂��낢��ȃt���[�o�[���g�����Ƃ��ł��܂��B���̃t�@�C����<span class="en">flavour</span>�͋M���̕t�����t���[�o�[���ɂ��܂��B</p><p>�Â��u���E�U�̂��߂�&quot;����1993&quot;�t���[�o�[���~�����H�@<span class="en">HTML</span>�t���[�o�[�ł�����悤��<span class="be">head.1993, foot.1993, story.1993</span>�t�@�C�����f�[�^�f�B���N�g���ɍ쐬���܂��傤�B �E�F�u���O��&quot;�^�C�g���̂�&quot;�ɂ���ɂ͑薼������\������t���[�o�[��p�ӂ���H�@�����ł��F <span class="be">head.titles, foot.titles, story.titles</span></p><p>����̃t���[�o�[�ŉ{������ɂ�<span class="en">Blosxom</span>��<span class="en">URL</span>�̍Ō��<span class="be">index.flavour</span>�Ǝw�肷�邩<span class="be">?flav=flavour</span>�i<span class="be">flavour</span>�̓t���[�o�[���j�Ǝw�肵�܂��B���̂��߁A�Ⴆ��<span class="en">1993</span>�t���[�o�[�̏ꍇ��<span class="be">http://localhost/cgi-bin/blosxom.cgi/index.1993</span> ��<span class="be">http://localhost/cgi-bin/blosxom.cgi/?flav=1993</span>�ɂȂ�܂��B</p><p>�ǂ��̂�<span class="en">index.flavour</span>�ł��B<span class="en">?flav=flavour</span>�͌Â��o�[�W������<span class="en">Blosxom</span>�Ƃ̌݊��̂��߂ɗp�ӂ���Ă��܂��B</p><p class="nextLink"><a href="doc_users_syndicate.html" class="bl">�V���W�P�[�g...</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</pre><p>以下のように表示されます：</p><p class="it">01/01/2003</p><p>テンプレートファイルをどこに保存するかとかどのテンプレートコンポーネントを自由に組み合わせてとか知っているのはさておき、これでは空は有限である事に違いありません。<span class="en">CSS</span>、<span class="en">JavaScript</span>、<span class="en">XML</span>、プレーンテキスト...を使ってガツガツいきましょう。貴方のウェブログです。好きなように作りましょう。</p><h3>たくさんのフレーバー...</h3><p>まだわき道に入るわけには行きません。フレーバーに付いて知っておくべきことが他にもちょっとあるのです... たくさんのフレーバー。それは貴方の興味と創造性のみに制限をうけます。 <span class="en">HTML</span>フレーバーと<span class="en">RSS</span>フレーバーは既に&quot;箱&quot;に入っていますが、<span class="be">head.flavour, foot.flavour, story.flavour, content_type.flavour, date.flavour</span>（オプション）と言うファイルを作ればいろいろなフレーバーを使うことができます。このファイルの<span class="en">flavour</span>は貴方の付けたフレーバー名にします。</p><p>古いブラウザのために&quot;西暦1993&quot;フレーバーが欲しい？　<span class="en">HTML</span>フレーバーでやったように<span class="be">head.1993, foot.1993, story.1993</span>ファイルをデータディレクトリに作成しましょう。 ウェブログを&quot;タイトルのみ&quot;にするには題名だけを表示するフレーバーを用意する？　そうです： <span class="be">head.titles, foot.titles, story.titles</span></p><p>特定のフレーバーで閲覧するには<span class="en">Blosxom</span>の<span class="en">URL</span>の最後で<span class="be">index.flavour</span>と指定するか<span class="be">?flav=flavour</span>（<span class="be">flavour</span>はフレーバー名）と指定します。そのため、例えば<span class="en">1993</span>フレーバーの場合は<span class="be">http://localhost/cgi-bin/blosxom.cgi/index.1993</span> か<span class="be">http://localhost/cgi-bin/blosxom.cgi/?flav=1993</span>になります。</p><p>良いのは<span class="en">index.flavour</span>です。<span class="en">?flav=flavour</span>は古いバージョンの<span class="en">Blosxom</span>との互換のために用意されています。</p><p class="nextLink"><a href="doc_users_syndicate.html" class="bl">シンジケート...</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_flavour.html
+++ b/doc_users_flavour.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_install_dynamic.html
+++ b/doc_users_install_dynamic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::インストール</title>
 

--- a/doc_users_install_dynamic.html
+++ b/doc_users_install_dynamic.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_install_dynamic.html
+++ b/doc_users_install_dynamic.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�C���X�g�[��</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::インストール</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,209 +11,209 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�C���X�g�[��</a></h1><h2><a name="mac_manual" class="anc"><span class="en">Mac</span>�Ɏ��ƂŃC���X�g�[��</a></h2><p> <span class="en">Blosxom</span>�͒P����<span class="en">CGI</span>�X�N���v�g�ł��̂ŃE�F�u�ŃA�N�Z�X�ł���ꏊ�ɒu���ȏ�̂��Ƃ͓��ɕK�v����܂���B�����A�ǂ��ɒu���Ƃ��A�K�v�ł���Α����ݒ�����Ď��s������^���āA��O�҂���ύX�ł��Ȃ��悤�ɂ���ƌ��������Ƃ͕K�v�ł��B</p><ol>
+<td id="contents"><h1><a name="top" class="bl">インストール</a></h1><h2><a name="mac_manual" class="anc"><span class="en">Mac</span>に手作業でインストール</a></h2><p> <span class="en">Blosxom</span>は単純な<span class="en">CGI</span>スクリプトですのでウェブでアクセスできる場所に置く以上のことは特に必要ありません。ただ、どこに置くとか、必要であれば多少設定をして実行権限を与えて、第三者から変更できないようにすると言ったことは必要です。</p><ol>
 <li> 
-<p>�Ƃ������V����<span class="en">Blosxom</span>����肵�܂��B<a href="downloads.html">�����Ń_�E�����[�h�ł��܂�</a>�B�𓀃\�t�g��<span class="en">ZIP</span>��W�J����ƁA�f�X�N�g�b�v��<span class="be">blosxom.cgi</span>���ł��܂��B</p>
+<p>ともかく新しい<span class="en">Blosxom</span>を入手します。<a href="downloads.html">ここでダウンロードできます</a>。解凍ソフトで<span class="en">ZIP</span>を展開すると、デスクトップに<span class="be">blosxom.cgi</span>ができます。</p>
 </li>
 <li> 
-<p><span class="en">Mac</span>��<span class="en">Apache</span>�E�F�u�T�[�o��<span class="en">CGI</span>�X�N���v�g��u���ꏊ�Ɋւ��đ����C����Ƃ��낪����܂��B<span class="be">blosxom.cgi</span>����ʂ�<span class="en">CGI</span>�f�B���N�g���ɒu���܂��B<span class="be">/Library/WebServer/CGI-Executables</span>�ł��B</p>
+<p><span class="en">Mac</span>の<span class="en">Apache</span>ウェブサーバは<span class="en">CGI</span>スクリプトを置く場所に関して多少気難しいところがあります。<span class="be">blosxom.cgi</span>を特別な<span class="en">CGI</span>ディレクトリに置きます。<span class="be">/Library/WebServer/CGI-Executables</span>です。</p>
 </li>
 <li> 
-<p><span class="be">blosxom.cgi</span>�����s�\�Ȃ悤�ɂ���K�v������܂��B�^�[�~�i���i<span class="be">/Applications/Utilities/Terminal</span>�j���N�����Ĉȉ��̂悤�ɃR�}���h����͂��܂��B</p>
+<p><span class="be">blosxom.cgi</span>が実行可能なようにする必要があります。ターミナル（<span class="be">/Applications/Utilities/Terminal</span>）を起動して以下のようにコマンドを入力します。</p>
 <pre class="en">chmod 755 /Library/WebServer/CGI-Executables/blosxom.cgi</pre>
 </li>
 <li> 
-<p><span class="en">Blosxom</span>�̃��O�͑S�āA���ʂȃt�H���_�ɒu����܂��B���O��u���̂ɗǂ��ꏊ��<span class="en">Apache</span>�̃E�F�u�y�[�W�̏ꏊ�A<span class="be">/Library/WebServer/Documents</span>�ł��B�^�[�~�i���ňȉ��̂悤�ɃR�}���h����͂��ăt�H���_���쐬���܂��B</p>
+<p><span class="en">Blosxom</span>のログは全て、特別なフォルダに置かれます。ログを置くのに良い場所は<span class="en">Apache</span>のウェブページの場所、<span class="be">/Library/WebServer/Documents</span>です。ターミナルで以下のようにコマンドを入力してフォルダを作成します。</p>
 <pre class="en">sudo mkdir /Library/WebServer/Documents/blosxom</pre>
-<p><span class="be">/Library/WebServer/Documents</span>�͒ʏ�A���[�U���������߂Ȃ��t�H���_�Ȃ̂Ńp�X���[�h����͂���悤�Ɍ����܂��B</p>
-<p>�V�����쐬����<span class="be">blosxom</span>�t�H���_�ɍD���ȂƂ��Ƀp�X���[�h�����ŏ������݂��������Ǝv���ł��傤�B�R�}���h���C���ňȉ��̂悤�ɓ��͂��܂��F</p>
+<p><span class="be">/Library/WebServer/Documents</span>は通常、ユーザが書き込めないフォルダなのでパスワードを入力するように言われます。</p>
+<p>新しく作成した<span class="be">blosxom</span>フォルダに好きなときにパスワード無しで書き込みをしたいと思うでしょう。コマンドラインで以下のように入力します：</p>
 <pre class="en">sudo chgrp staff /Library/WebServer/Documents/blosxom
 sudo chmod 775 /Library/WebServer/Documents/blosxom</pre>
-<p>�^�[�~�i�����I�����܂��i<span class="be">Command-Q</span> �܂��� <span class="be">Terminal 
+<p>ターミナルを終了します（<span class="be">Command-Q</span> または <span class="be">Terminal 
 &gt; Quit Terminal</span>)</p>
 </li>
 <li> 
-<p><span class="en">Apache</span>�E�F�u�T�[�o��<span class="en">Blosxom</span>�̃E�F�u���O�ɖK���O�ɓ��삵�Ă���K�v������܂��B�܂��N�����Ă��Ȃ��ꍇ�ɂ̓V�X�e���v���t�@�����X���N�����i<span class="be">Apple 
-Menu or Dock &gt; System Preferences</span>�j�A���L�ƃT�[�r�X�p�l����I�����܂��B�p�[�\�i���E�F�u���L�̃`�F�b�N�{�b�N�X���N���b�N���ăE�F�u�T�[�o�[���J�n���܂��B</p>
+<p><span class="en">Apache</span>ウェブサーバは<span class="en">Blosxom</span>のウェブログに訪れる前に動作している必要があります。まだ起動していない場合にはシステムプリファレンスを起動し（<span class="be">Apple 
+Menu or Dock &gt; System Preferences</span>）、共有とサービスパネルを選択します。パーソナルウェブ共有のチェックボックスをクリックしてウェブサーバーを開始します。</p>
 </li>
-</ol><p><span class="be">http://localhost/cgi-bin/blosxom.cgi</span>���u���E�U�ŊJ���Ă܂����������Ă��Ȃ�<span class="en">Blosxom</span>�̃E�F�u���O�����Ă݂܂��B<a href="doc_users_blog.html">�E�F�u���O</a>��<a href="doc_users_flavour.html">������</a>�̕ύX�����������͂��ł��B</p><p>�E�F�u���O���n�߂�O�Ɋ�����ݒ������̂��ǂ��ł��傤�B</p><h2><a name="isp" class="anc"><span class="be">ISP</span>�i�v���o�C�_�j�ɃC���X�g�[��</a></h2><p> <span class="en">Blosxom</span>�͒P����<span class="en">CGI</span>�X�N���v�g�ł��̂ŃE�F�u�ŃA�N�Z�X�ł���ꏊ�ɒu���ȏ�̂��Ƃ͓��ɕK�v����܂���B�����A�ǂ��ɒu���Ƃ��A�K�v�ł���Α����ݒ�����Ď��s������^���āA��O�҂���ύX�o���Ȃ��悤�ɂ���ƌ��������Ƃ͕K�v�ł��B</p><h3>�l�����邱��</h3><ul class="mid">
-<li><span class="en">ISP</span>���E�F�u�X�y�[�X�ƓƎ���<span class="en">CGI</span>�X�N���v�g���s�������Ă��邱�ƁB</li>
-<li>�E�F�u�A�N�Z�X�ł���f�B���N�g���ւ̃p�X�i��@<span class="be">/home/username/public_html</span>�j��m���Ă��邱�ƁB<span class="en">ISP</span>�ɂ���ĈقȂ�܂����A��ʂɂ̓z�[���f�B���N�g����<span class="be">www</span>�A<span class="be">public_html</span>�A<span class="be">web</span>���̃T�u�f�B���N�g�����Ǝv���܂��B</li>
-<li><span class="en">CGI</span>�X�N���v�g�̓E�F�u�A�N�Z�X�ł���f�B���N�g����<span class="be">cgi-bin</span>�T�u�f�B���N�g���ɒu���K�v������܂��B<br>
-�i��@<span class="be">/home/username/public_html/cgi-bin</span>�j�B</li>
-<li>�z�[���A�E�F�u�A�N�Z�X�A<span class="en">cgi-bin</span>�f�B���N�g���ɃA�N�Z�X�\�ȃA�J�E���g�ŃR�}���h���C���i<span class="en">telnet</span>��<span class="en">ssh</span>�j�܂���<span class="en">FTP</span>���g���邱�ƁB<span class="en">FTP</span>���g���ꍇ��<span class="en">FTP</span>�N���C�A���g�̎g�����Ȃǂ͂��낢�날��̂Ő������܂���B</li>
-</ul><p>��L�Ɋւ��ĉ����s���ȏꍇ�ɂ�<span class="en">ISP</span>�̃T�|�[�g�ɕ����Ă��������B</p><h3>�C���X�g�[��</h3><p> <span class="en">ISP</span>�̊��ɍ��킹�邽�߂ɂȂɂ����������蒲������K�v������Ƃ��Ă��A�ȉ��̐����ŏ\���Ή��ł���Ǝv���܂��B</p><ol>
+</ol><p><span class="be">http://localhost/cgi-bin/blosxom.cgi</span>をブラウザで開いてまだ何も書いていない<span class="en">Blosxom</span>のウェブログを見てみます。<a href="doc_users_blog.html">ウェブログ</a>や<a href="doc_users_flavour.html">見た目</a>の変更等何も無いはずです。</p><p>ウェブログを始める前に幾つか環境設定をするのも良いでしょう。</p><h2><a name="isp" class="anc"><span class="be">ISP</span>（プロバイダ）にインストール</a></h2><p> <span class="en">Blosxom</span>は単純な<span class="en">CGI</span>スクリプトですのでウェブでアクセスできる場所に置く以上のことは特に必要ありません。ただ、どこに置くとか、必要であれば多少設定をして実行権限を与えて、第三者から変更出来ないようにすると言ったことは必要です。</p><h3>考慮すること</h3><ul class="mid">
+<li><span class="en">ISP</span>がウェブスペースと独自の<span class="en">CGI</span>スクリプト実行を許可していること。</li>
+<li>ウェブアクセスできるディレクトリへのパス（例　<span class="be">/home/username/public_html</span>）を知っていること。<span class="en">ISP</span>によって異なりますが、一般にはホームディレクトリの<span class="be">www</span>、<span class="be">public_html</span>、<span class="be">web</span>等のサブディレクトリだと思います。</li>
+<li><span class="en">CGI</span>スクリプトはウェブアクセスできるディレクトリの<span class="be">cgi-bin</span>サブディレクトリに置く必要があります。<br>
+（例　<span class="be">/home/username/public_html/cgi-bin</span>）。</li>
+<li>ホーム、ウェブアクセス、<span class="en">cgi-bin</span>ディレクトリにアクセス可能なアカウントでコマンドライン（<span class="en">telnet</span>や<span class="en">ssh</span>）または<span class="en">FTP</span>が使えること。<span class="en">FTP</span>を使う場合の<span class="en">FTP</span>クライアントの使い方などはいろいろあるので説明しません。</li>
+</ul><p>上記に関して何か不明な場合には<span class="en">ISP</span>のサポートに聞いてください。</p><h3>インストール</h3><p> <span class="en">ISP</span>の環境に合わせるためになにかいじったり調整する必要があるとしても、以下の説明で十分対応できると思います。</p><ol>
 <li> 
-<p>�Ƃ������V����<span class="en">Blosxom</span>����肵�܂��B<a href="downloads.html">�����Ń_�E�����[�h�ł��܂��B</a>�𓀃\�t�g��<span class="en">ZIP</span>��W�J����<span class="be">blosxom.cgi</span>�����܂��B</p>
+<p>ともかく新しい<span class="en">Blosxom</span>を入手します。<a href="downloads.html">ここでダウンロードできます。</a>解凍ソフトで<span class="en">ZIP</span>を展開して<span class="be">blosxom.cgi</span>を作ります。</p>
 </li>
 <li> 
-<p><span class="be">blosxom.cgi</span>��<span class="en">ISP</span>�̃T�[�o�ɃA�b�v���[�h���i�ʏ��FTP���g���܂��j�A<span class="en">cgi-bin</span>�f�B���N�g���ɒu���܂��B</p>
+<p><span class="be">blosxom.cgi</span>を<span class="en">ISP</span>のサーバにアップロードし（通常はFTPを使います）、<span class="en">cgi-bin</span>ディレクトリに置きます。</p>
 <pre class="en">/home/username/public_html/cgi-bin/blosxom.cgi</pre>
 </li>
 <li> 
-<p><span class="en">blosxom.cgi</span>�����s�\�ɂ��܂��B�R�}���h���C�����g����ꍇ�͈ȉ��̂悤�ɓ��͂��܂��F</p>
+<p><span class="en">blosxom.cgi</span>を実行可能にします。コマンドラインが使える場合は以下のように入力します：</p>
 <pre class="en">chmod 755 /home/username/public_html/cgi-bin/blosxom.cgi</pre>
-<p>�p�X�͋M���̂��̂ɂ��ĉ������B</p>
-<p>�R�}���h���C���i<span class="en">telnet</span>��<span class="en">ssh</span>�j���g���Ȃ��ꍇ��<span class="en">FTP</span>�N���C�A���g�Ńp�[�~�b�V������ύX����K�v������܂��B�ڍׂ̓N���C�A���g�\�t�g�̐��������ĉ������B</p>
+<p>パスは貴方のものにして下さい。</p>
+<p>コマンドライン（<span class="en">telnet</span>や<span class="en">ssh</span>）が使えない場合は<span class="en">FTP</span>クライアントでパーミッションを変更する必要があります。詳細はクライアントソフトの説明を見て下さい。</p>
 </li>
 <li> 
-<p><span class="en">Blosxom</span>�̃��O�͑S�āA���ʂȃf�B���N�g��/�t�H���_�ɒu����܂��B���O��u���̂ɗǂ��ꏊ�͋M���̃z�[���f�B���N�g���i��@<span class="be">/home/username/blosxom</span>�j�ł��B<span class="en">FTP</span>�N���C�A���g��<span class="en">'mkdir'</span>�R�}���h/�{�^�����g�����A�܂��͂ňȉ��̂悤�ɃR�}���h����͂���<span class="be">blosxom</span>�f�B���N�g�����쐬���܂��B</p>
+<p><span class="en">Blosxom</span>のログは全て、特別なディレクトリ/フォルダに置かれます。ログを置くのに良い場所は貴方のホームディレクトリ（例　<span class="be">/home/username/blosxom</span>）です。<span class="en">FTP</span>クライアントの<span class="en">'mkdir'</span>コマンド/ボタンを使うか、またはで以下のようにコマンドを入力して<span class="be">blosxom</span>ディレクトリを作成します。</p>
 <pre class="en">mkdir /home/username/blosxom</pre>
-<p>�p�X�͓ǂݑւ��ĉ������B</p>
+<p>パスは読み替えて下さい。</p>
 </li>
-</ol><h2><a name="windows_manual" class="anc"><span class="be">Windows</span>�Ɏ��ƂŃC���X�g�[��</a> </h2><p> <span class="en">Blosxom</span>�͒P����<span class="en">CGI</span>�X�N���v�g�ł��̂ŃE�F�u�ŃA�N�Z�X�ł���ꏊ�ɒu���ȏ�̂��Ƃ͓��ɕK�v����܂���B�����A�ǂ��ɒu���Ƃ��A�K�v�ł���Α����ݒ�����Ď��s������^���āA��O�҂���ύX�o���Ȃ��悤�ɂ���ƌ��������Ƃ͕K�v�ł��B</p><ol>
+</ol><h2><a name="windows_manual" class="anc"><span class="be">Windows</span>に手作業でインストール</a> </h2><p> <span class="en">Blosxom</span>は単純な<span class="en">CGI</span>スクリプトですのでウェブでアクセスできる場所に置く以上のことは特に必要ありません。ただ、どこに置くとか、必要であれば多少設定をして実行権限を与えて、第三者から変更出来ないようにすると言ったことは必要です。</p><ol>
 <li> 
-<p>�Ƃ������V����<span class="en">Blosxom</span>����肵�܂��B<a href="downloads.html">�����Ń_�E�����[�h�ł��܂��B</a></p>
-</li>
-<li> 
-<p>�𓀃\�t�g��<span class="en">ZIP</span>���𓀂����<span class="be">blosxom.cgi</span>���ł��܂��B<span class="be">C:\Inetpub\wwwroot</span>�ɒ��ډ𓀂��邩�A�𓀌�ɂ����Ɏ��ƂŃh���b�O���܂��B</p>
+<p>ともかく新しい<span class="en">Blosxom</span>を入手します。<a href="downloads.html">ここでダウンロードできます。</a></p>
 </li>
 <li> 
-<p><span class="en">Blosxom</span>�̃��O�͑S�āA���ʂȃt�H���_�ɒu����܂��B���O��u���̂ɗǂ��ꏊ��<span class="en">IIS</span>�E�F�u�T�[�o�̃E�F�u�y�[�W�ꏊ�ł���A<span class="be">C:\Inetpub\wwwroot\blosxom</span>�@�ł��B�����s���Ă�����@��<span class="be">blosxom</span>�t�H���_���쐬���ĉ������B<a href="doc_users_configure.html">�ݒ�</a>��<span class="en">Blosxom</span>�����̃t�H���_����������悤�ɂ��܂��B</p>
+<p>解凍ソフトで<span class="en">ZIP</span>を解凍すると<span class="be">blosxom.cgi</span>ができます。<span class="be">C:\Inetpub\wwwroot</span>に直接解凍するか、解凍後にそこに手作業でドラッグします。</p>
 </li>
 <li> 
-<p>�ȉ��̂��Ƃ��s�����߂Ɋ��<span class="en">IIS</span>�̐ݒ肪����܂��B</p>
-<p>a) �E�F�u�T�[�o��<span class="be">blosxom.cgi</span>�X�N���v�g�̒��g��P���ɕ\�����Ă��܂�Ȃ��悤�ɒʒm����B<br>
-b) <span class="en">PATH_INFO</span>�i�Ӗ���m��Ȃ��Ă��\���܂���j�𐳂���������悤��<span class="en">IIS</span>�̃o�O���C������B</p>
-<p>���肪�������ƂɁA<span class="en">PerlMonks</span>�T�C�g��<a href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/iisref/html/psdk/asp/apro9tkj.asp"><span class="en">IIS</span>�̃X�N���v�g�}�b�v��K�؂Ɉ�����悤�ɂ���</a>�Z���C���p�X�N���v�g<a href="http://perlmonks.thepen.com/102907.html"><span class="en">&quot;Fix 
-ActiveState Script Maps (IIS)&quot;</span></a>��񋟂��Ă��܂��B</p>
+<p><span class="en">Blosxom</span>のログは全て、特別なフォルダに置かれます。ログを置くのに良い場所は<span class="en">IIS</span>ウェブサーバのウェブページ場所である、<span class="be">C:\Inetpub\wwwroot\blosxom</span>　です。いつも行っている方法で<span class="be">blosxom</span>フォルダを作成して下さい。<a href="doc_users_configure.html">設定</a>で<span class="en">Blosxom</span>がこのフォルダを見つけられるようにします。</p>
+</li>
+<li> 
+<p>以下のことを行うために幾つか<span class="en">IIS</span>の設定があります。</p>
+<p>a) ウェブサーバに<span class="be">blosxom.cgi</span>スクリプトの中身を単純に表示してしまわないように通知する。<br>
+b) <span class="en">PATH_INFO</span>（意味を知らなくても構いません）を正しく扱えるように<span class="en">IIS</span>のバグを修正する。</p>
+<p>ありがたいことに、<span class="en">PerlMonks</span>サイトが<a href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/iisref/html/psdk/asp/apro9tkj.asp"><span class="en">IIS</span>のスクリプトマップを適切に扱えるようにする</a>短い修正用スクリプト<a href="http://perlmonks.thepen.com/102907.html"><span class="en">&quot;Fix 
+ActiveState Script Maps (IIS)&quot;</span></a>を提供しています。</p>
 <ol>
 <li> 
-<p>�E�F�u�u���E�U���璼�ڃX�N���v�g���R�s�[���܂��B<span class="en">Windows</span>�̃X�^�[�g�{�^�����N���b�N����&quot;�t�@�C�������w�肵�Ď��s&quot;��I�����܂��B<span class="en">command</span>����͂���<span class="en">OK</span>���N���b�N���܂��B�R�}���h���C���ł͈ȉ��̂悤�ɓ��͂��܂��F</p>
+<p>ウェブブラウザから直接スクリプトをコピーします。<span class="en">Windows</span>のスタートボタンをクリックして&quot;ファイル名を指定して実行&quot;を選択します。<span class="en">command</span>を入力して<span class="en">OK</span>をクリックします。コマンドラインでは以下のように入力します：</p>
 <pre class="en">C:\&gt;edit fixiis.pl</pre>
-<p>�e�L�X�g�G�f�B�^���N�����܂��B</p>
+<p>テキストエディタが起動します。</p>
 </li>
 <li> 
-<p>�R�[�h��\��t���A�ۑ����A�G�f�B�^���I�����܂��B</p>
+<p>コードを貼り付け、保存し、エディタを終了します。</p>
 </li>
 <li> 
-<p>�V�����쐬���ꂽ�X�N���v�g���ȉ��̂悤�ɋN�����܂��F</p>
+<p>新しく作成されたスクリプトを以下のように起動します：</p>
 <pre class="en">C:\&gt;c:\perl\bin\perl fixiis.pl</pre>
-<p>���ɂ�����폜���Ă����܂��F</p>
+<p>次にこれを削除しておきます：</p>
 <pre class="en">C:\&gt;del fixiis.p</pre>
 <li> 
-<p>�R�}���h�E�C���h�E����܂��B</p>
+<p>コマンドウインドウを閉じます。</p>
 </li>
 </ol>
 </li>
-</ol><p>����܂ł�<span class="en">Blosxom</span>�̃C���X�g�[���ł����B���ɐݒ�����܂��B�������A��ɐi�ޑO�Ɋ�����ӂ�����܂�...</p><ul>
+</ol><p>これまでは<span class="en">Blosxom</span>のインストールでした。次に設定をします。しかし、先に進む前に幾つか注意があります...</p><ul>
 <li> 
-<p><span class="en">Windows</span>�̓p�X�̋�؂�Ƀo�b�N�X���b�V���i���{��ł́��j���g���܂����A<span class="en">Perl</span>�ł̓X���b�V���i/�j���g���܂��B���̂��߁A�f�[�^�f�B���N�g���̎w���<span class="be">C:/Inetpub/wwwroot/blosxom</span> 
-�̂悤�ɏ����܂��B</p>
+<p><span class="en">Windows</span>はパスの区切りにバックスラッシュ（日本語では¥）を使いますが、<span class="en">Perl</span>ではスラッシュ（/）を使います。そのため、データディレクトリの指定は<span class="be">C:/Inetpub/wwwroot/blosxom</span> 
+のように書きます。</p>
 </li>
 <li> 
-<p><span class="be">blosxom.cgi</span>�X�N���v�g�̕ҏW�ɂ͍D���ȃe�L�X�g�G�f�B�^���g���܂��B</p>
+<p><span class="be">blosxom.cgi</span>スクリプトの編集には好きなテキストエディタを使えます。</p>
 </li>
-</ul><p class="nextLink"><a href="doc_users_configure.html" class="bl"><span class="be">Blosxom</span>�̐ݒ�...</a></p><h2><a name="mac" class="anc"><span class="en">Mac</span>�ɃC���X�g�[��</a> </h2><p><span class="en">Mac OS X</span>��<span class="en">Blosxom</span>���C���X�g�[������ɂ�2�̊�{�I���@������܂��F</p><ul>
+</ul><p class="nextLink"><a href="doc_users_configure.html" class="bl"><span class="be">Blosxom</span>の設定...</a></p><h2><a name="mac" class="anc"><span class="en">Mac</span>にインストール</a> </h2><p><span class="en">Mac OS X</span>に<span class="en">Blosxom</span>をインストールするには2つの基本的方法があります：</p><ul>
 <li> 
-<p><span class="en">Mac OS X</span>�p��<span class="en">Blosxom</span>�C���X�g�[�����g���Ɖ��񂩂̃N���b�N�ŃC���X�g�[�����鎖���ł��܂��B�����ɃT���v����<a href="doc_users_flavour.html">�t���[�o�[�e���v���[�g</a>�A�h�L�������g�A������ --�f���炵������-- ���C�ɓ����<a href="plugin_registry.html">�֗��ȃv���O�C��</a>���C���X�g�[�����܂��B�p�b�P�[�W�ɓ��Ă��Ėʓ|�Ȃ��Ƃ�����Ȃ炱��͂Ƃ��Ă��ǂ��͂��ł��I</p>
-<p><a href="downloads.html" class="bl">�C���X�g�[���̃_�E�����[�h...</a></p>
+<p><span class="en">Mac OS X</span>用の<span class="en">Blosxom</span>インストーラを使うと何回かのクリックでインストールする事ができます。同時にサンプルの<a href="doc_users_flavour.html">フレーバーテンプレート</a>、ドキュメント、そして --素晴らしすぎる-- お気に入りの<a href="plugin_registry.html">便利なプラグイン</a>もインストールします。パッケージに馴れていて面倒なことがいやならこれはとっても良いはずです！</p>
+<p><a href="downloads.html" class="bl">インストーラのダウンロード...</a></p>
 </li>
 <li> 
-<p>����������ƁA�M���͎����ł�肽���l�ŁA<span class="en">Blosxom</span>���ǂ������������肽�������m��܂���B�Ȃ�A�X�N���v�g���_�E�����[�h���ēK�؂ȃf�B���N�g�������A�ݒ��������|���Ă��ǂ��ł��傤�B</p>
-<p><a href="#mac_manual" class="bl">���Ƃł̃C���X�g�[��...</a></p>
+<p>もしかすると、貴方は自分でやりたい人で、<span class="en">Blosxom</span>がどう動くかいじりたいかも知れません。なら、スクリプトをダウンロードして適切なディレクトリを作り、設定をいじり倒しても良いでしょう。</p>
+<p><a href="#mac_manual" class="bl">手作業でのインストール...</a></p>
 </li>
-</ul><p><a href="doc_users_install_dynamic.html">�C���X�g�[������������̂�����������̂ł���΂������N���b�N�B</a></p><h2><a name="install" class="anc">�C���X�g�[��</a></h2><p><span class="en">Blosxom</span>�͂ǂ��ł����삷��悤�ɐ݌v����Ă��܂��B��ʓI��<span class="en">OS</span>�i(<span class="en">Mac OS X</span>�A<span class="en">Windows 2000/XP</span>�A<span class="en">Unix/Linux</span>�j�A�E�F�u�T�[�o�i<span class="en">Apache</span>�A<span class="en">IIS</span>�j�A<span class="en">Perl</span>�i<span class="en">Perl 
-4/5</span>�j�̊��œ��삵�܂��B</p><p>�C���X�g�[���͂ł��邾���ȒP�Ȃ悤�ɐ݌v����Ă��܂��B�v���O���~���O��C���X�g�[���Ɋւ���K�v�Ȓm���͂����킸���ł��B</p><dl> 
+</ul><p><a href="doc_users_install_dynamic.html">インストーラが何をするのか興味があるのであればここをクリック。</a></p><h2><a name="install" class="anc">インストール</a></h2><p><span class="en">Blosxom</span>はどこでも動作するように設計されています。一般的な<span class="en">OS</span>（(<span class="en">Mac OS X</span>、<span class="en">Windows 2000/XP</span>、<span class="en">Unix/Linux</span>）、ウェブサーバ（<span class="en">Apache</span>、<span class="en">IIS</span>）、<span class="en">Perl</span>（<span class="en">Perl 
+4/5</span>）の環境で動作します。</p><p>インストールはできるだけ簡単なように設計されています。プログラミングやインストールに関する必要な知識はごくわずかです。</p><dl> 
 <dt class="en">ISP</dt>
 <dd> 
-<p>�E�F�u�y�[�W��u���ēƎ�<span class="en">CGI</span>�X�N���v�g�����s�ł���<span class="en">ISP</span>�̃A�J�E���g���K�v�ł��B</p>
-<p><a href="doc_users_install_dynamic.html" class="bl">�C���X�g�[������...</a></p>
+<p>ウェブページを置けて独自<span class="en">CGI</span>スクリプトが実行できる<span class="en">ISP</span>のアカウントが必要です。</p>
+<p><a href="doc_users_install_dynamic.html" class="bl">インストールする...</a></p>
 </dd>
 <dt class="en">Mac</dt>
 <dd> 
-<p><span class="en">Mac OS X</span>�̃m�[�g�≟����ɂ��܂����Â��f�X�N�g�b�v�B</p>
-<p><a href="doc_users_install_dynamic.html" class="bl">�C���X�g�[������...</a></p>
+<p><span class="en">Mac OS X</span>のノートや押入れにしまった古いデスクトップ。</p>
+<p><a href="doc_users_install_dynamic.html" class="bl">インストールする...</a></p>
 </dd>
 <dt class="en">Windows</dt>
 <dd> 
-<p><span class="en">IIS</span>��������<span class="en">Windows 2000/XP</span>�B</p>
-<p><a href="doc_users_install_dynamic.html" class="bl">�C���X�g�[������...</a></p>
+<p><span class="en">IIS</span>が入った<span class="en">Windows 2000/XP</span>。</p>
+<p><a href="doc_users_install_dynamic.html" class="bl">インストールする...</a></p>
 </dd>
 <dt class="en">Unix/Linux</dt>
 <dd> 
-<p>�C���X�g�[����ݒ�CGI�X�N���v�g�̋N���ȂǑ����m���Ă���K�v������܂����A<span class="en">ISP</span>�ł̃C���X�g�[�����Q�l�ɂ���΂ł���ł��傤�B</p>
-<p><a href="doc_users_install_dynamic.html" class="bl">�C���X�g�[������...</a></p>
+<p>インストールや設定CGIスクリプトの起動など多少知っている必要がありますが、<span class="en">ISP</span>でのインストールを参考にすればできるでしょう。</p>
+<p><a href="doc_users_install_dynamic.html" class="bl">インストールする...</a></p>
 </dd>
-</dl><h2><a name="mac_installer" class="anc"><span class="en">Mac OS X</span>�p�C���X�g�[�����g��</a></h2><p><a href="downloads.html">�C���X�g�[��</a>�͎��Ƃōs��Ȃ���΂Ȃ�Ȃ�<a href="doc_users_install_dynamic.html">�C���X�g�[��</a>��<a href="doc_users_configure.html">�ݒ�</a>��S�čs���܂��B</p><ul>
+</dl><h2><a name="mac_installer" class="anc"><span class="en">Mac OS X</span>用インストーラを使う</a></h2><p><a href="downloads.html">インストーラ</a>は手作業で行わなければならない<a href="doc_users_install_dynamic.html">インストール</a>と<a href="doc_users_configure.html">設定</a>を全て行います。</p><ul>
 <li> 
-<p><span class="be">blosxom.cgi</span>�i<span class="en">Blosxom CGI</span>�X�N���v�g�{�́j��<span class="be">/Library/WebServer/CGI-Executables/blosxom.cgi</span>�ɃC���X�g�[������܂��B</p>
+<p><span class="be">blosxom.cgi</span>（<span class="en">Blosxom CGI</span>スクリプト本体）は<span class="be">/Library/WebServer/CGI-Executables/blosxom.cgi</span>にインストールされます。</p>
 </li>
 <li> 
-<p><span class="be">Blosxom</span>�t�H���_�i�S�ẴE�F�u���O��ۑ�����ꏊ�j��<span class="be">/Library/WebServer/Documents/Blosxom</span>�ɍ쐬����ÓI�\���p�̋��<span class="be">blog</span>�t�H���_��<span class="be">/Library/WebServer/Documents/blog</span>�ɍ쐬����܂��B</p>
+<p><span class="be">Blosxom</span>フォルダ（全てのウェブログを保存する場所）は<span class="be">/Library/WebServer/Documents/Blosxom</span>に作成され静的表示用の空の<span class="be">blog</span>フォルダが<span class="be">/Library/WebServer/Documents/blog</span>に作成されます。</p>
 </li>
 <li> 
-<p>�v���O�C���f�B���N�g����<span class="be">/Library/WebServer/Data/Blosxom/plugins/</span>�ɍ쐬����A<span class="en">writeback</span>�A<span class="en">wikieditish</span>�A<span class="en">breadcrumbs</span>�A<span class="en">config</span>�A<span class="en">interpolate_conditional</span>�A<span class="en">sort_by_name</span>�A<span class="en">sort_by_path</span>�ƌ����l�C�������ĕ֗��ȃv���O�C���𗘗p�\�ɂ��܂��B</p>
+<p>プラグインディレクトリが<span class="be">/Library/WebServer/Data/Blosxom/plugins/</span>に作成され、<span class="en">writeback</span>、<span class="en">wikieditish</span>、<span class="en">breadcrumbs</span>、<span class="en">config</span>、<span class="en">interpolate_conditional</span>、<span class="en">sort_by_name</span>、<span class="en">sort_by_path</span>と言う人気があって便利なプラグインを利用可能にします。</p>
 </li>
 <li> 
-<p><span class="be">/etc/httpd/users/blosxom.conf</span>��<span class="en">Apache</span>�ݒ�t�@�C����<span class="en">Apache</span>��<span class="be">/weblog</span>����<span class="be">/cgi-bin/blosxom.cgi</span>�ւ̃G�C���A�X�ݒ�f�B���N�e�B�u���܂�ł��܂��B</p>
+<p><span class="be">/etc/httpd/users/blosxom.conf</span>の<span class="en">Apache</span>設定ファイルは<span class="en">Apache</span>に<span class="be">/weblog</span>から<span class="be">/cgi-bin/blosxom.cgi</span>へのエイリアス設定ディレクティブを含んでいます。</p>
 </li>
 <li> 
-<p>�E�F�u���O�̓E�F�u���O�`���̊���̃h�L�������g�Ɗ֘A�t�����Ă��܂��B������ <span class="be">/Library/WebServer/Documents/Blosxom/docs</span>�ɂ���܂��B</p>
+<p>ウェブログはウェブログ形式の幾つかのドキュメントと関連付けられています。それらは <span class="be">/Library/WebServer/Documents/Blosxom/docs</span>にあります。</p>
 </li>
 <li> 
-<p>����̃T���v���t���[�o�[��<span class="be">/Library/WebServer/Documents/Blosxom</span>�ɂ���܂��̂Ŗ��͓I�ȃE�F�u���O�𒼂��Ɏn�߂鎖���ł��܂��B</p>
+<p>幾つかのサンプルフレーバーが<span class="be">/Library/WebServer/Documents/Blosxom</span>にありますので魅力的なウェブログを直ぐに始める事ができます。</p>
 </li>
 <li> 
-<p>�֗��Ȃ悤�ɁA<span class="be">Blosxom</span>�t�H���_�ƃz�[���ւ̃G�C���A�X��<span class="bl">�f�X�N�g�b�v</span>�ɍ쐬����܂��B</p>
+<p>便利なように、<span class="be">Blosxom</span>フォルダとホームへのエイリアスが<span class="bl">デスクトップ</span>に作成されます。</p>
 </li>
 <li> 
-<p>���܂��܂̃p�[�~�b�V�����Ɗ��ݒ肪�s���܂��B�_�C�A���O�{�b�N�X�Ŋ���₢���킹���i�I�v�V�����j����܂��B</p>
+<p>さまざまのパーミッションと環境設定が行われます。ダイアログボックスで幾つか問い合わせが（オプション）あります。</p>
 </li>
 <li> 
-<p>�E�F�u�T�[�o���i�āj�N�����A�����I�ɂ��C�ɓ���̃u���E�U�ŃE�F�u���O���\������܂��B <span class="en">URL</span>�� <span class="be">http://127.0.0.1/weblog/docs</span>�ł��B</p>
+<p>ウェブサーバが（再）起動し、自動的にお気に入りのブラウザでウェブログが表示されます。 <span class="en">URL</span>は <span class="be">http://127.0.0.1/weblog/docs</span>です。</p>
 </li>
-</ul><p>�A�b�v�O���[�h�̓C���X�g�[��������S�Ă̎����s���A�ŏ��Ɋ����̃t�@�C�����ړ����Č��݂̓��t�Ǝ��Ԃ�t�����܂��B</p><p>���̂���<span class="be">blosxom.cgi</span>��<span class="be">blosxom.cgi.datestamp</span>�ɖ��O���ύX����<span class="be">blosxom 
-datadir</span>��<span class="be">blog staticdir</span>��<span class="be">blosxom.datestamp</span>��<span class="be">blog.datestamp</span>�ɂȂ�܂��B�Â�<span class="en">blosxom.cgi.datestamp</span> <span class="en">CGI</span>�X�N���v�g�̃p�[�~�b�V�����͖����ɂ��邽�߂ɕύX����܂��B�C���X�g�[����<span class="en">Apahe</span>�̊��t�@�C���ł���<span class="en">blosxom.conf</span>���㏑�����܂��B</p><p class="nextLink"><a href="downloads.html" class="bl">�C���X�g�[���̃_�E�����[�h..</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</ul><p>アップグレードはインストールがする全ての事を行い、最初に既存のファイルを移動して現在の日付と時間を付加します。</p><p>そのため<span class="be">blosxom.cgi</span>は<span class="be">blosxom.cgi.datestamp</span>に名前が変更され<span class="be">blosxom 
+datadir</span>と<span class="be">blog staticdir</span>は<span class="be">blosxom.datestamp</span>と<span class="be">blog.datestamp</span>になります。古い<span class="en">blosxom.cgi.datestamp</span> <span class="en">CGI</span>スクリプトのパーミッションは無効にするために変更されます。インストーラは<span class="en">Apahe</span>の環境ファイルである<span class="en">blosxom.conf</span>を上書きします。</p><p class="nextLink"><a href="downloads.html" class="bl">インストーラのダウンロード..</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_overview.html
+++ b/doc_users_overview.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::概要</title>
 

--- a/doc_users_overview.html
+++ b/doc_users_overview.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�T�v</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::概要</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,63 +11,63 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�T�v</a></h1><h2>�C���X�g�[��</h2><p><span class="en">Blosxom</span>�͂ǂ��ł����삷��悤�ɐ݌v����Ă��܂��B��ʓI��<span class="en">OS</span>�i(<span class="en">Mac OS X</span>�A<span class="en">Windows 2000/XP</span>�A<span class="en">Unix/Linux</span>�j�A�E�F�u�T�[�o�i<span class="en">Apache</span>�A<span class="en">IIS</span>�j�A<span class="en">Perl</span>�i<span class="en">Perl 4/5</span>�j�̊��œ��삵�܂��B</p><p><a href="doc_users_install_dynamic.html#install">�C���X�g�[���S�ʂ̏ڍׂ͂������</a></p><h2><span class="en">ISP</span>�i�v���o�C�_�j�ɃC���X�g�[��</h2><p><span class="en">ISP</span>�̊��ɍ��킹�邽�߂ɂȂɂ����������蒲������K�v������Ƃ��Ă��A�ȉ��̐����ŏ\���Ή��ł���Ǝv���܂��B</p><p><a href="doc_users_install_dynamic.html#isp"><span class="en">ISP</span>�ւ̃C���X�g�[���ڍׂ͂������</a></p><h2><span class="en">Mac</span>�Ɏ��ƂŃC���X�g�[��</h2><p><span class="en">Mac</span>��<span class="en">Apache</span>�E�F�u�T�[�o��<span class="en">CGI</span>�X�N���v�g��u���ꏊ�Ɋւ��đ����C����Ƃ��낪����܂��B<span class="en">blosxom.cgi</span>����ʂ�<span class="en">CGI</span>�f�B���N�g���ɒu���܂��B<span class="en">/Library/WebServer/CGI-Executables</span>�ł��B</p><p><a href="doc_users_install_dynamic.html#mac_manual"><span class="en">Mac</span>�ւ̎��Ƃł̃C���X�g�[���ڍׂ͂������</a></p><h2><span class="be">Mac</span>�ɃC���X�g�[��</h2><p><span class="en">Mac OS X</span>��<span class="en">Blosxom</span>���C���X�g�[������ɂ�2�̊�{�I���@������܂��F</p><p><a href="doc_users_install_dynamic.html#mac"><span class="en">Mac</span>�ւ̃C���X�g�[���ڍׂ͂������</a></p><h2><span class="en">Mac OS X</span>�p�C���X�g�[�����g��</h2><p>�C���X�g�[���͎��Ƃōs��Ȃ���΂Ȃ�Ȃ��C���X�g�[���Ɛݒ��S�čs���܂��B</p><p><a href="doc_users_install_dynamic.html#MAC_INSTALLER"><span class="en">Mac</span>�p�C���X�g�[�����g�����C���X�g�[���ڍׂ͂������</a></p><h2><span class="en">Windows</span>�Ɏ��ƂŃC���X�g�[��</h2><p>���<span class="en">IIS</span>�̐ݒ肪����܂��B</p><p><a href="doc_users_install_dynamic.html#windows_manual"><span class="en">Windows</span>�ւ̃C���X�g�[���ڍׂ͂������</a></p><h2>�ݒ�</h2><p><span class="en">Blosxom</span>�̑S�Ă̐ݒ�͊ȒP�̂��߃X�N���v�g���g�ɏ�����Ă��܂��B����鎖�͂���܂���B�S�Ăɖʔ����������t���Ă��܂����A�{���ɒP���ł��B�W���ł͈ȉ��̂悤�ɂȂ��Ă��܂��F</p><p> <a href="doc_users_configure.html#configure"><span class="en">Blosxom</span>�̐ݒ�ڍׂ͂������</a></p><h2>�E�F�u���O</h2><p>�C�̐��E�ł͓����������쐶�̒��Ŏ��R�ɐU�����̂Ɠ��l�ɁA<span class="en">Blosxom</span>�͋M���̏�������ς���悤�Ȃ��Ƃ͂��܂���B�D���ȃe�L�X�g�G�f�B�^�i<span class="en">BBEdit</span>�A�������A<span class="en">Emacs</span>�A<span class="en">Word</span>���j���g���ĕҏW���s���܂��B</p><p><a href="doc_users_blog.html">�E�F�u���O�̕t�����̏ڍׂ͂������</a></p><h2>�{��</h2><p>�E�F�u���O���u���E�U�ŉ{���ł��Ȃ���΃E�F�u���O���Ă��Ă����ɂ��y��������܂���B<span class="en">Blosxom</span>�ɂ͑����̉{�����@������܂��F</p><p><a href="doc_users_view.html">�E�F�u���O�̉{���̕��@�͂������</a></p><h2>�t���[�o�[�i<span class="en">Flavour</span>�j</h2><p><span class="en">Blosxom</span>��2�̃t���[�o�[��\�ߒ񋟂��Ă��܂��B��{�̃f�t�H���g <span class="en">HTML</span>��<span class="en">XML</span>�x�[�X�̃V���W�P�[�g�̂��߂�<span class="en">RSS</span>�ł��B</p><p><a href="doc_users_flavour.html">�t���[�o�[�ɂ��Ă̏ڍׂ͂������</a></p><h2>�v���O�C��</h2><p><span class="en">Blosxom</span>�̃v���O�C���A�[�L�e�N�`���ɂ����<span class="en">Blosxom</span>�̊j�ƂȂ镔���͌y�ʂ��X�}�[�g�̂܂܂ɁA�قȂ���◘�p���@�ɑ΂���g������񋟂��Ă��܂��B</p><p><a href="doc_users_plugins.html">�v���O�C���̏ڍׂ͂������</a></p><h2>�ÓI�\��</h2><p>���C���̃C���f�b�N�X�A�J�e�S���C���f�b�N�X�A�����ē��t�C���f�b�N�X�ɑ΂��Ă��炩���߃t�@�C�����쐬���Ă����āA�ÓI�ɂ����\�����邽�߂̃R�}���h���C���ōs���@�\������܂��B
-</p><p><a href="doc_users_configure_static.html">�ÓI�\���̏ڍׂ͂������</a></p><h2>�V���W�P�[�g�i�A���j</h2><p>�V���W�P�[�g�͖K��҂ɃT�C�g�ɗ��Ă���킸�ɐV�������e�𑼎҂ɒm���Ă��炤���̂ł��B</p><p><a href="doc_users_syndicate.html">�V���W�P�[�g�̏ڍׂ͂������</a></p><h2>�ǉ���<span class="be">FAQ</span></h2><p><span class="en">Blosxom</span>�̏��Z��g���b�N�A�Z�p�A���̑�����<span class="en">Blosxom</span>�R�~���j�e�B�Ƌ��L�ł�������������ł����H�@������<span class="en">FAQ</span>�i�Ɖ񓚁j��ǉ����ĉ������I�@������ƌ��Ă���FAQ�ɒǉ����܂��B</p><p><a href="http://www.blosxom.com/documentation/users/">���e�̎��ۂ̏ꏊ�͂����ł��F</a></p><ul class="mid">
-<li>����</li>
-<li>����</li>
-<li>�J�e�S��</li>
-<li>���O</li>
+<td id="contents"><h1><a name="top" class="bl">概要</a></h1><h2>インストール</h2><p><span class="en">Blosxom</span>はどこでも動作するように設計されています。一般的な<span class="en">OS</span>（(<span class="en">Mac OS X</span>、<span class="en">Windows 2000/XP</span>、<span class="en">Unix/Linux</span>）、ウェブサーバ（<span class="en">Apache</span>、<span class="en">IIS</span>）、<span class="en">Perl</span>（<span class="en">Perl 4/5</span>）の環境で動作します。</p><p><a href="doc_users_install_dynamic.html#install">インストール全般の詳細はこちらへ</a></p><h2><span class="en">ISP</span>（プロバイダ）にインストール</h2><p><span class="en">ISP</span>の環境に合わせるためになにかいじったり調整する必要があるとしても、以下の説明で十分対応できると思います。</p><p><a href="doc_users_install_dynamic.html#isp"><span class="en">ISP</span>へのインストール詳細はこちらへ</a></p><h2><span class="en">Mac</span>に手作業でインストール</h2><p><span class="en">Mac</span>の<span class="en">Apache</span>ウェブサーバは<span class="en">CGI</span>スクリプトを置く場所に関して多少気難しいところがあります。<span class="en">blosxom.cgi</span>を特別な<span class="en">CGI</span>ディレクトリに置きます。<span class="en">/Library/WebServer/CGI-Executables</span>です。</p><p><a href="doc_users_install_dynamic.html#mac_manual"><span class="en">Mac</span>への手作業でのインストール詳細はこちらへ</a></p><h2><span class="be">Mac</span>にインストール</h2><p><span class="en">Mac OS X</span>に<span class="en">Blosxom</span>をインストールするには2つの基本的方法があります：</p><p><a href="doc_users_install_dynamic.html#mac"><span class="en">Mac</span>へのインストール詳細はこちらへ</a></p><h2><span class="en">Mac OS X</span>用インストーラを使う</h2><p>インストーラは手作業で行わなければならないインストールと設定を全て行います。</p><p><a href="doc_users_install_dynamic.html#MAC_INSTALLER"><span class="en">Mac</span>用インストーラを使ったインストール詳細はこちらへ</a></p><h2><span class="en">Windows</span>に手作業でインストール</h2><p>幾つか<span class="en">IIS</span>の設定があります。</p><p><a href="doc_users_install_dynamic.html#windows_manual"><span class="en">Windows</span>へのインストール詳細はこちらへ</a></p><h2>設定</h2><p><span class="en">Blosxom</span>の全ての設定は簡単のためスクリプト自身に書かれています。恐れる事はありません。全てに面白い文字が付いていますし、本当に単純です。標準では以下のようになっています：</p><p> <a href="doc_users_configure.html#configure"><span class="en">Blosxom</span>の設定詳細はこちらへ</a></p><h2>ウェブログ</h2><p>海の世界では動物たちが野生の中で自然に振舞うのと同様に、<span class="en">Blosxom</span>は貴方の書き方を変えるようなことはしません。好きなテキストエディタ（<span class="en">BBEdit</span>、メモ帳、<span class="en">Emacs</span>、<span class="en">Word</span>等）を使って編集を行います。</p><p><a href="doc_users_blog.html">ウェブログの付け方の詳細はこちらへ</a></p><h2>閲覧</h2><p>ウェブログをブラウザで閲覧できなければウェブログしていても何にも楽しくありません。<span class="en">Blosxom</span>には多くの閲覧方法があります：</p><p><a href="doc_users_view.html">ウェブログの閲覧の方法はこちらへ</a></p><h2>フレーバー（<span class="en">Flavour</span>）</h2><p><span class="en">Blosxom</span>は2つのフレーバーを予め提供しています。基本のデフォルト <span class="en">HTML</span>と<span class="en">XML</span>ベースのシンジケートのための<span class="en">RSS</span>です。</p><p><a href="doc_users_flavour.html">フレーバーについての詳細はこちらへ</a></p><h2>プラグイン</h2><p><span class="en">Blosxom</span>のプラグインアーキテクチャによって<span class="en">Blosxom</span>の核となる部分は軽量かつスマートのままに、異なる環境や利用方法に対する拡張性を提供しています。</p><p><a href="doc_users_plugins.html">プラグインの詳細はこちらへ</a></p><h2>静的表示</h2><p>メインのインデックス、カテゴリインデックス、そして日付インデックスに対してあらかじめファイルを作成しておいて、静的にそれを表示するためのコマンドラインで行う機能があります。
+</p><p><a href="doc_users_configure_static.html">静的表示の詳細はこちらへ</a></p><h2>シンジケート（連合）</h2><p>シンジケートは訪問者にサイトに来てもらわずに新しい内容を他者に知ってもらうものです。</p><p><a href="doc_users_syndicate.html">シンジケートの詳細はこちらへ</a></p><h2>追加と<span class="be">FAQ</span></h2><p><span class="en">Blosxom</span>の小技やトリック、技術、その他何か<span class="en">Blosxom</span>コミュニティと共有できる情報をお持ちですか？　ここで<span class="en">FAQ</span>（と回答）を追加して下さい！　ちらっと見てからFAQに追加します。</p><p><a href="http://www.blosxom.com/documentation/users/">投稿の実際の場所はここです：</a></p><ul class="mid">
+<li>質問</li>
+<li>答え</li>
+<li>カテゴリ</li>
+<li>名前</li>
 <li class="en">URL</li>
-</ul><p><a href="faq.html"><span class="en">FAQ</span>�̃y�[�W�͂������</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</ul><p><a href="faq.html"><span class="en">FAQ</span>のページはこちらへ</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_overview.html
+++ b/doc_users_overview.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_plugins.html
+++ b/doc_users_plugins.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::プラグイン</title>
 

--- a/doc_users_plugins.html
+++ b/doc_users_plugins.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_plugins.html
+++ b/doc_users_plugins.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�v���O�C��</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::プラグイン</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,95 +11,95 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�v���O�C��</a></h1><h2>�v���O�C��</h2><p><span class="en">Blosxom</span>�̃v���O�C���A�[�L�e�N�`���ɂ����<span class="en">Blosxom</span>�̊j�ƂȂ镔���͌y�ʂ��X�}�[�g�̂܂܂ɁA�قȂ���◘�p���@�ɑ΂���g������񋟂��Ă��܂��B</p>
-<h3>�v���O�C���̓o�^...</h3><p><a href="plugin_registry.html">�v���O�C���̓o�^�y�[�W</a>�����ĕK�v�ȃv���O�C����T���ĉ������B</p><p>�����ɂ͂��傤�ǋM���̂悤��<span class="en">Blosxom</span>���[�U���J�������v���O�C�������X�g�A�b�v�����Ă���A�����𑱂��Ă��܂��B�����ł̓v���O�C�����񂳂�Ă��āA�v���O�C���ɑ΂���R�����g��ǂ񂾂�ł��܂����A�ǉ��e���v���[�g���������肵�܂��B�摜�v���O�C���͉摜�Q�Ƃ���T�C�Y�ύX�܂őS�Ă�񋟂��Ă��܂��̂ŃM�������[���\�z���鎖���ł��܂��B���͌n�̃v���O�C���͕ԐM�i�R�����g�ƃg���b�N�o�b�N�j�A���ʊ֌W�̒ǐՁA���[�����E�F�u���O�ɂ���ƌ������@�\��񋟂��Ă��܂��B</p>
-<h3>�v���O�C����L���ɂ���...</h3><p><span class="en">Blosxom</span>�Ńv���O�C����L���ɂ���ɂ́A�v���O�C����u���f�B���N�g�����쐬���Ă��̏ꏊ��<span class="en">Blosxom</span>�ɋ����܂��B</p>
+<td id="contents"><h1><a name="top" class="bl">プラグイン</a></h1><h2>プラグイン</h2><p><span class="en">Blosxom</span>のプラグインアーキテクチャによって<span class="en">Blosxom</span>の核となる部分は軽量かつスマートのままに、異なる環境や利用方法に対する拡張性を提供しています。</p>
+<h3>プラグインの登録...</h3><p><a href="plugin_registry.html">プラグインの登録ページ</a>を見て必要なプラグインを探して下さい。</p><p>そこにはちょうど貴方のような<span class="en">Blosxom</span>ユーザが開発したプラグインがリストアップさえており、成長を続けています。そこではプラグインが陳列されていて、プラグインに対するコメントを読んだりできますし、追加テンプレートがあったりします。画像プラグインは画像参照からサイズ変更まで全てを提供していますのでギャラリーを構築する事ができます。入力系のプラグインは返信（コメントとトラックバック）、因果関係の追跡、メールをウェブログにすると言った機能を提供しています。</p>
+<h3>プラグインを有効にする...</h3><p><span class="en">Blosxom</span>でプラグインを有効にするには、プラグインを置くディレクトリを作成してその場所を<span class="en">Blosxom</span>に教えます。</p>
 <ol>
 <li>
-<p>�ǂ��ł��ǂ��̂Ńv���O�C����u���t�H���_/�f�B���N�g�����쐬���܂��B�B��̌��܂�́A�v���O�C���͑��҂��猩�����Ԃɂ��ׂ��ł͂Ȃ��ƌ������ł��B�v���O�C���̓v���O�����ł���<span class="en">Tom</span>�A<span class="en">Dick</span>������<span class="en">Harry</span>�ɂ͓ǂ܂ꂽ���͂Ȃ��ݒ�I�v�V������p�X���[�h���܂�ł��邱�Ƃ��ǂ�����܂��B�E�F�u�T�[�o�̃h�L�������g���[�g���痣���ĉ������B</p>
-<p><span class="be">state</span>�f�B���N�g�����K�v�ł��B�����̃v���O�C�������炩�̃t�@�C���������A������ۑ�����K�v�����邽�߂ł��B</p>
-<p>�v���O�C����u��������ł��F</p>
+<p>どこでも良いのでプラグインを置くフォルダ/ディレクトリを作成します。唯一の決まりは、プラグインは他者から見られる状態にすべきではないと言う事です。プラグインはプログラムであり<span class="en">Tom</span>、<span class="en">Dick</span>そして<span class="en">Harry</span>には読まれたくはない設定オプションやパスワードを含んでいることが良くあります。ウェブサーバのドキュメントルートから離して下さい。</p>
+<p><span class="be">state</span>ディレクトリも必要です。多くのプラグインが何らかのファイルを扱い、それらを保存する必要があるためです。</p>
+<p>プラグインを置く手引きです：</p>
 
 <dl>
 <dt class="en">ISP</dt>
 <dd>
-<p><span class="be">data/blosxom/plugins</span>�f�B���N�g�����z�[���f�B���N�g���ɒu���̂��ǂ��ł��傤�B�R�}���h���C�����g����̂ł���΁A�ȉ��̃R�}���h��<span class="be">plugins</span>��<span class="be">plugins/state</span>���쐬���邱�Ƃ��ł��܂��F</p>
+<p><span class="be">data/blosxom/plugins</span>ディレクトリをホームディレクトリに置くのが良いでしょう。コマンドラインが使えるのであれば、以下のコマンドで<span class="be">plugins</span>と<span class="be">plugins/state</span>を作成することができます：</p>
 <pre class="en">
 mkdir -p ~/data/blosxom/plugins/state
 chmod -R 755 ~/data/blosxom/plugins/state
 </pre>
-<p><span class="en">FTP</span>�̂ݎg����ꍇ�ɂ͂��g����<span class="en">FTP</span>�A�v���P�[�V������<span class="be">data/blosxom/plugins/state</span>�ƌ����K�w�����܂��B</p>
+<p><span class="en">FTP</span>のみ使える場合にはお使いの<span class="en">FTP</span>アプリケーションで<span class="be">data/blosxom/plugins/state</span>と言う階層を作ります。</p>
 </dd>
 
 <dt class="en">Mac OS X</dt>
 <dd>
-<p><span class="be">/Library/WebServer/Data/Blosxom/Plugins</span>���Ă��܂��B<a href="downloads.html"><span class="en">Blosxom</span>�C���X�g�[��</a>���g�����ꍇ�ɂ͋M���̐ݒ�ɂ���ĈႢ�܂��B�g���Ă��Ȃ��ꍇ�ɂ̓^�[�~�i�����N�����āA�ȉ��̂悤�ɓ��͂��܂��F</p>
+<p><span class="be">/Library/WebServer/Data/Blosxom/Plugins</span>を提案します。<a href="downloads.html"><span class="en">Blosxom</span>インストーラ</a>を使った場合には貴方の設定によって違います。使っていない場合にはターミナルを起動して、以下のように入力します：</p>
 <pre class="en">
 sudo mkdir -p /Library/WebServer/Data/Blosxom/Plugins
 sudo chmod -R 755 /Library/WebServer/Data/Blosxom/Plugins
 </pre>
-<p>�i�p�X���[�h���͂��K�v��������܂���j</p>
+<p>（パスワード入力が必要かもしれません）</p>
 </dd>
 
 <dt class="en">Windows 2000/XP</dt>
 <dd>
-<p>�G�N�X�v���[���� <span class="be">c:\Inetpub\Data\Blosxom\Plugins\state</span>���쐬���܂��B</p>
+<p>エクスプローラで <span class="be">c:\Inetpub\Data\Blosxom\Plugins\state</span>を作成します。</p>
 </dd>
 </dl>
 
 </li>
 
 <li>
-<p><span class="be">blosxom.cgi</span>�X�N���v�g�ɂ���<span class="be">$plugin_dir</span>���g����<span class="en">Blosxom</span>�Ƀv���O�C���̏ꏊ�������܂��B �e�L�X�g�G�f�B�^��<span class="en">blosxom.cgi</span>���J���A�ȉ��̕�����T���܂��F</p>
+<p><span class="be">blosxom.cgi</span>スクリプトにある<span class="be">$plugin_dir</span>を使って<span class="en">Blosxom</span>にプラグインの場所を教えます。 テキストエディタで<span class="en">blosxom.cgi</span>を開き、以下の部分を探します：</p>
 <pre class="en">
 # --- Plugins (Optional) -----
 
@@ -110,12 +110,12 @@ $plugin_dir = &quot;&quot;;
 $plugin_state_dir = &quot;$plugin_dir/state&quot;;
 </pre>
 
-<p><span class="en">$plugin_dir</span>�̒l��1.�ō쐬�����v���O�C���f�B���N�g���̏ꏊ�ɕς��܂��B��L�̐����ɏ]�����Ƃ���΁A�ȉ����K�؂Ȑݒ�ɂȂ�܂��F</p>
+<p><span class="en">$plugin_dir</span>の値を1.で作成したプラグインディレクトリの場所に変えます。上記の説明に従ったとすれば、以下が適切な設定になります：</p>
 
 <dl>
 <dt class="en">ISP</dt>
 <dd>
-<p><span class="be">data/blosxom/plugins/state</span>���w�肷�邽�߂ɂ̓t���p�X��m���Ă���K�v������܂��B�Ⴆ�΃z�[���f�B���N�g����<span class="be">/home/sam</span>�̏ꍇ�ɂ̓v���O�C���̐ݒ�͈ȉ��̒ʂ�ł��F</p>
+<p><span class="be">data/blosxom/plugins/state</span>を指定するためにはフルパスを知っている必要があります。例えばホームディレクトリが<span class="be">/home/sam</span>の場合にはプラグインの設定は以下の通りです：</p>
 <pre class="en"># Where are my plugins kept?
 $plugin_dir = &quot;/home/sam/data/blosxom/plugins&quot;;
 </pre>
@@ -123,7 +123,7 @@ $plugin_dir = &quot;/home/sam/data/blosxom/plugins&quot;;
 
 <dt class="en">Mac OS X</dt>
 <dd>
-<p><a href="downloads.html"><span class="en">Blosxom</span>�C���X�g�[��</a>���g�����ꍇ�ɂ͈ȉ����s���K�v�͂���܂���B</p>
+<p><a href="downloads.html"><span class="en">Blosxom</span>インストーラ</a>を使った場合には以下を行う必要はありません。</p>
 <pre class="en">
 # Where are my plugins kept?
 $plugin_dir = &quot;/Library/WebServer/Data/Blosxom/Plugins&quot;;
@@ -131,7 +131,7 @@ $plugin_dir = &quot;/Library/WebServer/Data/Blosxom/Plugins&quot;;
 
 <dt class="en">Windows 2000/XP</dt>
 <dd>
-<p><span class="en">Windows</span>�̓p�X�̋�؂�Ƀo�b�N�X���b�V���i���{��ł́��j���g���܂����A<span class="en">Perl</span>�ł̓X���b�V���i<span class="en">/</span>�j���g���܂��F</p>
+<p><span class="en">Windows</span>はパスの区切りにバックスラッシュ（日本語では¥）を使いますが、<span class="en">Perl</span>ではスラッシュ（<span class="en">/</span>）を使います：</p>
 <pre class="en">
 # Where are my plugins kept?
 $plugin_dir = &quot;c:/Inetpub/Data/Blosxom/Plugins&quot;;
@@ -139,10 +139,10 @@ $plugin_dir = &quot;c:/Inetpub/Data/Blosxom/Plugins&quot;;
 </dd>
 </dl>
 </li>
-</ol><p>�����<span class="en">Blosxom</span>�Ńv���O�C�����g����悤�ɂȂ�܂����B�M���������v���O�C���������Ă���΂ł���...</p>
-<h3>�v���O�C���̃C���X�g�[��...</h3><p>�v���O�C���̃C���X�g�[���̓v���O�C����<span class="be">plugins</span>�f�B���N�g���ɃR�s�[���邾���ł��B�v���O�C���ɂ���Ă͍Œ���̐ݒ肪�K�v�ȏꍇ������܂��B��҂̐����i�ʏ�A�v���O�C���t�@�C���̉��ɏ�����Ă��܂��j�ɏ]���ĉ������B</p><p><span class="en">Blosxom</span>�͎���A�E�F�u���O���������Ɏ����Ńv���O�C���������ēǂݍ��݂܂��B</p>
-<h3>�v���O�C���̏���...</h3><p><span class="en">Blosxom</span>�͎����Ńv���O�C���������A�ǂݍ��݁A�Ăяo���܂��B����̓A���t�@�x�b�g���ōs���܂��B�Ⴆ��<span class="be">config</span>��<span class="be">sort_by_path</span>���O�œǂݍ��܂�܂��B<span class="be">sort_by_path</span>��<span class="be">writeback</span>�̑O�ɓǂݍ��܂�܂��B</p><p>�v���O�C���̓ǂݍ��ݏ��𑀍삵�����ꍇ�ɂ́A�t�@�C�����̑O�ɐ��������܂��F <span class="be">00loadfirst, 50loadsometime, 99loadlast,  ...</span></p>
-<h3>�v���O�C���𖳌��ɂ���...</h3><p>�v���O�C���f�B���N�g������v���O�C�����폜����΂��̃v���O�C�������ł������ɂ��邱�Ƃ��ł��܂��B�����Ɨǂ����@�Ƃ��āA�t�@�C�����̌�ɃA���_�[�X�R�A�i_�j��t���邱�Ƃ��ł����F <span class="be">someplugin</span> �� <span class="be">someplugin_</span> �ɁB����ň��S�ɁA�������v���O�C���{�̂��f�B���N�g���Ɏc�����܂ܖ����ɂł��܂��B</p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</ol><p>これで<span class="en">Blosxom</span>でプラグインが使えるようになりました。貴方が何かプラグインを持っていればですが...</p>
+<h3>プラグインのインストール...</h3><p>プラグインのインストールはプラグインを<span class="be">plugins</span>ディレクトリにコピーするだけです。プラグインによっては最低限の設定が必要な場合があります。作者の説明（通常、プラグインファイルの下に書かれています）に従って下さい。</p><p><span class="en">Blosxom</span>は次回、ウェブログを見た時に自動でプラグインを見つけて読み込みます。</p>
+<h3>プラグインの順番...</h3><p><span class="en">Blosxom</span>は自動でプラグインを見つけ、読み込み、呼び出します。それはアルファベット順で行われます。例えば<span class="be">config</span>は<span class="be">sort_by_path</span>より前で読み込まれます。<span class="be">sort_by_path</span>は<span class="be">writeback</span>の前に読み込まれます。</p><p>プラグインの読み込み順を操作したい場合には、ファイル名の前に数字をつけます： <span class="be">00loadfirst, 50loadsometime, 99loadlast,  ...</span></p>
+<h3>プラグインを無効にする...</h3><p>プラグインディレクトリからプラグインを削除すればそのプラグインをいつでも無効にすることができます。もっと良い方法として、ファイル名の後にアンダースコア（_）を付けることができす： <span class="be">someplugin</span> を <span class="be">someplugin_</span> に。これで安全に、しかもプラグイン本体をディレクトリに残したまま無効にできます。</p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_syndicate.html
+++ b/doc_users_syndicate.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::シンジケート（Syndication）</title>
 

--- a/doc_users_syndicate.html
+++ b/doc_users_syndicate.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_syndicate.html
+++ b/doc_users_syndicate.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�V���W�P�[�g�iSyndication�j</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::シンジケート（Syndication）</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,56 +11,56 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�V���W�P�[�g�i<span class="en">Syndication</span>�j</a></h1><p><span class="en">RSS</span>��R���e���c�V���W�P�[�g�����������̃E�F�u���O�ɂ��Ă̌��t�͂قƂ�ǌ���܂���ł����B�V���W�P�[�g�͖K��҂ɃT�C�g�ɗ��Ă���킸�ɐV�������e�𑼎҂ɒm���Ă��炤���̂ł��B���Ԃ�&quot;<span class="en">RSS</span>���[�_�[&quot;�ƌĂ΂��f�X�N�g�b�v�œ��삷��j���[�X���[�_�[�⃁�[���\�t�g�̂悤�ȃA�v���P�[�V�������g���ăR���e���c��ǂނ��Ƃ��ł��܂��B  �R���e���c�͋����[���A�����ĕ֗��ȑg�ݍ��킹�ő��̃R���e���c�ɋM���̃R���e���c��D�������&quot;<span class="en">RSS</span>���W��&quot;�ɂ���Ď��グ���܂��B</p><p><span class="en">Blosxom</span>��<span class="en">XML</span>�i�قƂ�ǂ̐l���{���ł���<span class="en">HTML</span>�Ƃ͑Ώ̂̂��́j�Ƃ��ċM���̋L���𕡐����邱�Ƃɂ���ăE�F�u���O�̃V���W�P�[�g���\�ɂ��܂��B�ȉ���<span class="en">Blosxom</span>�j���[�X�̊T�v��<span class="en">RSS</span>�ɂ������̂ł��F </p>
+<td id="contents"><h1><a name="top" class="bl">シンジケート（<span class="en">Syndication</span>）</a></h1><p><span class="en">RSS</span>やコンテンツシンジケートが無い当時のウェブログについての言葉はほとんど語られませんでした。シンジケートは訪問者にサイトに来てもらわずに新しい内容を他者に知ってもらうものです。仲間は&quot;<span class="en">RSS</span>リーダー&quot;と呼ばれるデスクトップで動作するニュースリーダーやメールソフトのようなアプリケーションを使ってコンテンツを読むことができます。  コンテンツは興味深く、そして便利な組み合わせで他のコンテンツに貴方のコンテンツを織り交ぜる&quot;<span class="en">RSS</span>収集屋&quot;によって取り上げられます。</p><p><span class="en">Blosxom</span>は<span class="en">XML</span>（ほとんどの人が閲覧できる<span class="en">HTML</span>とは対称のもの）として貴方の記事を複製することによってウェブログのシンジケートを可能にします。以下は<span class="en">Blosxom</span>ニュースの概要を<span class="en">RSS</span>にしたものです： </p>
 <pre class="en">&lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!-- name=&quot;generator&quot; content=&quot;blosxom/2.0&quot; --&gt;
 &lt;!DOCTYPE rss PUBLIC &quot;-//Netscape Communications//DTD RSS 0.91//EN&quot;
@@ -87,11 +87,11 @@
   &lt;/channel&gt;
 &lt;/rss&gt;
 </pre>
-<p>�E�F�u���O��<span class="en">RSS</span>�o�[�W�����𓾂�ɂ�<span class="en">Blosxom</span>��<span class="en">URL</span>�̍Ō��<span class="be">index.rss</span> (�܂���<span class="be">?flav=rss</span>)�����܂��B�z�[���y�[�W��<span class="en">RSS</span>�͈ȉ��Ŏ擾�ł��܂��F</p><pre class="en">
+<p>ウェブログの<span class="en">RSS</span>バージョンを得るには<span class="en">Blosxom</span>の<span class="en">URL</span>の最後に<span class="be">index.rss</span> (または<span class="be">?flav=rss</span>)をつけます。ホームページの<span class="en">RSS</span>は以下で取得できます：</p><pre class="en">
 http://www.example.com/blosxom.cgi/index.rss
-</pre><p>�����<a href="doc_users_overview.html">�p�X</a>��<a href="doc_users_overview.html">���t</a>���ł��g���܂��B�Ⴆ��2003�N7����<span class="en">RSS</span>�͈ȉ��̂悤�ɂ��܂��F</p><pre class="en">
+</pre><p>これは<a href="doc_users_overview.html">パス</a>や<a href="doc_users_overview.html">日付</a>けでも使えます。例えば2003年7月の<span class="en">RSS</span>は以下のようにします：</p><pre class="en">
 blosxom.cgi/home/repair/2003/07/index.rss
-</pre><p>����ɂ���ċ����̂���K�w��<span class="en">RSS</span>���擾�ł��܂��B</p><p class="nextLink"><a href="doc_users_plugins.html" class="bl">�v���O�C����<span class="en">Blosxom</span>���g������...</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</pre><p>これによって興味のある階層の<span class="en">RSS</span>を取得できます。</p><p class="nextLink"><a href="doc_users_plugins.html" class="bl">プラグインで<span class="en">Blosxom</span>を拡張する...</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_view.html
+++ b/doc_users_view.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�{��</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::閲覧</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,89 +11,89 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�{��</a></h1><h2>�{��</h2><p>�E�F�u���O���u���E�U�ŉ{���ł��Ȃ���΃E�F�u���O���Ă��Ă����ɂ��y��������܂���B<span class="en">Blosxom</span>�ɂ͑����̉{�����@������܂��F �����ƁA�p�X/�J�e�S���A�����̃R���r�l�[�V�����B</p><p>�ȒP�Ɏn�߂邽�߁A�ŐV�̃E�F�u���O�ɒ��ڂ��ċM���̃E�F�u���O�y�[�W��������ƌ��Ă݂܂��傤�B</p><p>�����ł͊e�E�F�u���O�̃x�[�X<span class="en">URL</span>�͏�������Ă��Ă��܂��B�h���C�����^�p���Ă���̂��A<span class="en">ISP</span>���g���Ă���̂��A���[�J���̃}�V���Ȃ̂����Ɉˑ����Ă��܂��B���A������Ƃ����q���g������܂��F</p>
+<td id="contents"><h1><a name="top" class="bl">閲覧</a></h1><h2>閲覧</h2><p>ウェブログをブラウザで閲覧できなければウェブログしていても何にも楽しくありません。<span class="en">Blosxom</span>には多くの閲覧方法があります： 日ごと、パス/カテゴリ、それらのコンビネーション。</p><p>簡単に始めるため、最新のウェブログに注目して貴方のウェブログページをちらっと見てみましょう。</p><p>ここでは各ウェブログのベース<span class="en">URL</span>は少し違っていています。ドメインを運用しているのか、<span class="en">ISP</span>を使っているのか、ローカルのマシンなのか等に依存しています。が、ちょっとしたヒントがあります：</p>
 <ul>
 <li>
-<p><span class="en">Mac OS X�AWindows</span>�m�[�g�A�f�X�N�g�b�v�A���b�N�}�E���g�̏ꍇ��<span class="be">http://localhost/cgi-bin/blosxom.cgi</span> �ŉ{���ł��܂��B</p>
+<p><span class="en">Mac OS X、Windows</span>ノート、デスクトップ、ラックマウントの場合は<span class="be">http://localhost/cgi-bin/blosxom.cgi</span> で閲覧できます。</p>
 </li>
 <li>
-<p><span class="en">ISP</span>�i�v���o�C�_�j�̓��ʂ�<span class="be">cgi-bin</span>�f�B���N�g���ɃC���X�g�[�������ꍇ�ɂ͑��A <span class="be">http://www.serviceprovider.com/~username/cgi-bin/blosxom.cgi</span> �ɂȂ�܂��B<span class="be">serviceprovider.com</span>��<span class="en">ISP</span>�̃h���C����<span class="be">username</span>�͋M���̃��[�U���ł��B</p>
+<p><span class="en">ISP</span>（プロバイダ）の特別な<span class="be">cgi-bin</span>ディレクトリにインストールした場合には大抵、 <span class="be">http://www.serviceprovider.com/~username/cgi-bin/blosxom.cgi</span> になります。<span class="be">serviceprovider.com</span>は<span class="en">ISP</span>のドメインで<span class="be">username</span>は貴方のユーザ名です。</p>
 </li>
 <li>
-<p><span class="en">ISP</span>���g���Ă��Ă��h���C���������Ă���Ƃ��́A <span class="be">http://www.yourdomain.com/blosxom.cgi</span> ��  <span class="be">http://www.yourdomain.com/cgi-bin/blosxom.cgi</span> �������Ă݂ĉ������B<span class="be">yourdomain.com</span>�͋M���̃h���C�����ł��B</p>
+<p><span class="en">ISP</span>を使っていてもドメインを持っているときは、 <span class="be">http://www.yourdomain.com/blosxom.cgi</span> や  <span class="be">http://www.yourdomain.com/cgi-bin/blosxom.cgi</span> を試してみて下さい。<span class="be">yourdomain.com</span>は貴方のドメイン名です。</p>
 </li>
 </ul>
-<p>��肭�����ΕW����<span class="en">Blosxom</span>�̌����ڂŕ\������܂� --�ʔ����Ȃ������m��܂��񂪒����ɒ����܂�-- �M����<a href="doc_users_blog.html">�쐬</a>�����E�F�u���O���\������Ă���͂��ł��B</p>
-<h3>���Ԃ������̂ڂ���...</h3><p>�E�F�u���O�͓��t���ŕ\������܂� --�R�[���t���[�g�ŃN���[���i�ŐV�L���j�������Ԃ悤��--�B�Â��L���͉������Ă����A���ɂ���Ă͈�ԉ��ɗ����鎞������܂��B�ǂ��ɁA���[�A�ǂ����A�Â��L���͂ǂ��ɁH�@���[�A�ǂ��ɁA�����A�ǂ��ɍs�����񂾁H</p><p>���̂悤�ȌÂ��L�����A�N�A���A���ŉ{�����鎖���ł��܂��B����ɂ͒P�Ɍ��������t�̐�����<span class="en">URL</span>�ɒǉ����邾���ł��F</p><ul>
+<p>上手くいけば標準の<span class="en">Blosxom</span>の見た目で表示されます --面白くないかも知れませんが直ぐに直せます-- 貴方が<a href="doc_users_blog.html">作成</a>したウェブログが表示されているはずです。</p>
+<h3>時間をさかのぼって...</h3><p>ウェブログは日付順で表示されます --コーラフロートでクリーム（最新記事）が浮かぶように--。古い記事は下がっていき、時によっては一番下に落ちる時もあります。どこに、あー、どこだ、古い記事はどこに？　あー、どこに、もう、どこに行ったんだ？</p><p>このような古い記事を、年、月、日で閲覧する事ができます。それには単に見たい日付の数字を<span class="en">URL</span>に追加するだけです：</p><ul>
 <li>
-<p>�N�Ŏw�肷��ɂ�4���̐�����ǉ����܂��B2003�N�ł����<span class="en">URL</span>�͈ȉ��̂悤�Ȋ����ɂȂ�܂��F</p>
+<p>年で指定するには4桁の数字を追加します。2003年であれば<span class="en">URL</span>は以下のような感じになります：</p>
 <pre class="en">blosxom.cgi/2003</pre>
 </li>
 
 <li>
-<p>���Ŏw�肷��ɂ�4���̔N��2���̌���ǉ����܂��i01����12��1������12���ł��j�B2003�N5���̏ꍇ�́F</p>
+<p>月で指定するには4桁の年と2桁の月を追加します（01から12で1月から12月です）。2003年5月の場合は：</p>
 <pre class="en">
 blosxom.cgi/2003/05
 </pre>
 </li>
 
 <li>
-<p>����̓��̏ꍇ��4���̔N�A2���̌��A������2���̓���ǉ����܂��B2003�N3��22���́F</p>
+<p>特定の日の場合は4桁の年、2桁の月、そして2桁の日を追加します。2003年3月22日は：</p>
 <pre class="en">
 blosxom.cgi/2003/05/22
 </pre>
 </li>
 </ul>
-<h3>�p�X��n�����...</h3><p><span class="en">Blosxom</span>�̑��ݗ��R�Ƃ��Ă�������̂́A���ɋM�����m���Ă���t�@�C���ƃt�H���_/�f�B���N�g���ƌ������̂��E�F�u���O�Ƃ��Ċ��p�ł��鎖�ł��B�M���̃R���s���[�^�̃n�[�h�f�B�X�N�́A�v�l�A�v���W�F�N�g�A�������A�ǂ��d���A�t�B�N�V�����̃f�[�^�x�[�X�ł��B�M���̓v���W�F�N�g��ړI�ŁA�܂��͉��ƂȂ��͂����肵�Ȃ��M���̌l�I�Ȑ������@�̖񑩂Ɋ�Â��ĕ������t�@�C�����O���Ă���ł��傤�B<span class="en">Blosxom</span>�͂��̌o���Ɋ�Â��č\�z���A�E�F�u���O�̌`�ł����̊K�w�̈ꕔ��\�����܂��B</p><p>���̌l�I�ȊK�w�ɂ��Ă�����Ƃ̊ԂƂ�Ƃ߂̂Ȃ����b�����܂��傤�B���͌l�I�Ȗ񑩂ɍ����A�ړI�̊K�w��\������t�H���_�̒��̃t�H���_�̒��̃t�H���_�̒�...�ɕ�����ۑ����悤�Ƃ��܂��B���́A&quot;<span class="en">temporary</span>&quot;�̓����ɉB��Ă���&quot;<span class="en">etc</span>&quot;�ƃ}�[�N��������̃t�H���_�̉���ɖ����ꂽ���̂ł��A�ȑO�ɋl�ߍ��񂾂��̂�����邱�Ƃ��ł��܂��B����ɂ͂��g�D�����ꂽ�}�t�\��������܂��F</p><pre class="en">
+<h3>パスを渡り歩く...</h3><p><span class="en">Blosxom</span>の存在理由としてあげられるのは、既に貴方が知っているファイルとフォルダ/ディレクトリと言うものをウェブログとして活用できる事です。貴方のコンピュータのハードディスクは、思考、プロジェクト、愚かさ、良い仕事、フィクションのデータベースです。貴方はプロジェクトや目的で、または何となくはっきりしない貴方の個人的な整理方法の約束に基づいて物事をファイリングしているでしょう。<span class="en">Blosxom</span>はこの経験に基づいて構築し、ウェブログの形でそれらの階層の一部を表示します。</p><p>私の個人的な階層についてちょっとの間とりとめのないお話をしましょう。私は個人的な約束に合う、目的の階層を表現するフォルダの中のフォルダの中のフォルダの中...に物事を保存しようとします。私は、&quot;<span class="en">temporary</span>&quot;の内部に隠れている&quot;<span class="en">etc</span>&quot;とマークした幾つかのフォルダの奥底に埋もれたものでも、以前に詰め込んだものを大抵見つけることができます。これにはより組織化された枝葉構造があります：</p><pre class="en">
 ...
 /computers
 /computers/internet
@@ -106,26 +106,26 @@ blosxom.cgi/2003/05/22
 /computers/operating_systems/apple/mac_os_x
 ...
 </pre>
-<p>���̓e�L�X�g�̐؂�[�A�C���^�[�l�b�g�V���[�g�J�b�g�A�h�L�������g�����đ��̉�� <span class="en">/computers/operating_systems/apple/mac_os_x</span> �ƌ����t�H���_�ɒu���܂��B���̃t�H���_���̂�&quot;<span class="en">mac_os_x</span>&quot;�ƌĂ�ł��āA�c��S�Ă͂����ɓ����p�X�ɂȂ��Ă��܂��B</p><p>�����ă��[�J���̃n�[�h�f�B�X�N�ɂ��̖񑩂Ɋ�Â��ĕ�����g�D�����邾���ł͂Ȃ��āA���̃E�F�u���O�ɔ��f���ꂽ����̃J�e�S���\��������܂��B <a href="http://www.raelity.org/archives/computers/operating_systems/apple/mac_os_x" class="en">/computers/operating_systems/apple/mac_os_x</a> �͎���<span class="en">Mac OS X</span>�Ɋ֘A�����E�F�u���O�G���g����S�ĕۑ����Ă��܂��B������<span class="en">Blosxom</span>�Ɋւ��Ă� <a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom" class="en">/computers/internet/weblogs/blosxom</a>�ɃE�F�u���O���쐬���Ă��܂��B</p><p><span class="en">Blosxom</span>�̃E�F�u���O�ɋM���̌l�I�ȃJ�e�S���K�w�𔽉f���邱�Ƃ́A�P�ɓK�؂ȃf�B���N�g���ɋL���i<span class="en">.txt</span>�t�@�C���j��ۑ����鎖�Ȃ̂ł��B&quot;���t&quot;�Ɋւ��ď�������������������āH�@�Ȃ�A<span class="en">/society/language</span> �� <span class="en">/communication/spoken/language</span>�A�܂��͋M�����C�ɓ������t�H���_�ɓ���q�ɂȂ����t�H���_������ċL���������ɕۑ�����Ηǂ��̂ł��B</p><p>�u���E�U��<span class="en">Blosxom</span>�̃f�B���N�g���c���[��n������ɂ́A<span class="en">Blosxom</span>�̃x�[�X<span class="en">URL</span>�̍Ō�Ƀp�X��t���邾���Ƃ����ȒP�Ȃ��̂ł��B</p><p>�����āA<span class="en">Blosxom</span>��<a href="doc_users_configure.html" class="en">depth</a>�ݒ������Ă������Ƃ���΁i0�Ŗ����j�A�K�w�������čs�����Ƃł��̃f�B���N�g��/�t�H���_�̋L�������ł͂Ȃ��A���̃f�B���N�g��/�t�H���_�̉��ɂ��鑼�̑S�Ă��{���ł��܂��B��ԏ�̊K�w�ł͑S�Ă��{���ł��܂��B<span class="be">/travel</span>�ł�<span class="be">/travel</span>���̑S�āA<span class="be">/travel/india</span>�ł�<span class="be">/travel/india</span>���̑S�Ăƌ��������ɁB</p><p>���w�Ɋւ��鎄�̋L���ł��F</p><pre class="en">
+<p>私はテキストの切れ端、インターネットショートカット、ドキュメントそして他の塊を <span class="en">/computers/operating_systems/apple/mac_os_x</span> と言うフォルダに置きます。このフォルダ自体は&quot;<span class="en">mac_os_x</span>&quot;と呼んでいて、残り全てはそこに導くパスになっています。</p><p>そしてローカルのハードディスクにこの約束に基づいて物事を組織化するだけではなくて、私のウェブログに反映された幾つかのカテゴリ構造もあります。 <a href="http://www.raelity.org/archives/computers/operating_systems/apple/mac_os_x" class="en">/computers/operating_systems/apple/mac_os_x</a> は私の<span class="en">Mac OS X</span>に関連したウェブログエントリを全て保存しています。そして<span class="en">Blosxom</span>に関しては <a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom" class="en">/computers/internet/weblogs/blosxom</a>にウェブログを作成しています。</p><p><span class="en">Blosxom</span>のウェブログに貴方の個人的なカテゴリ階層を反映することは、単に適切なディレクトリに記事（<span class="en">.txt</span>ファイル）を保存する事なのです。&quot;言葉&quot;に関して書きたい何かがあるって？　なら、<span class="en">/society/language</span> や <span class="en">/communication/spoken/language</span>、または貴方が気に入ったフォルダに入れ子になったフォルダを作って記事をそこに保存すれば良いのです。</p><p>ブラウザで<span class="en">Blosxom</span>のディレクトリツリーを渡り歩くには、<span class="en">Blosxom</span>のベース<span class="en">URL</span>の最後にパスを付けるだけという簡単なものです。</p><p>そして、<span class="en">Blosxom</span>の<a href="doc_users_configure.html" class="en">depth</a>設定を放っておいたとすれば（0で無限）、階層を下って行くことでそのディレクトリ/フォルダの記事だけではなく、そのディレクトリ/フォルダの下にある他の全てが閲覧できます。一番上の階層では全てが閲覧できます。<span class="be">/travel</span>では<span class="be">/travel</span>内の全て、<span class="be">/travel/india</span>では<span class="be">/travel/india</span>内の全てと言う感じに。</p><p>文学に関する私の記事です：</p><pre class="en">
 blosxom.cgi/society/literature/
 </pre>
-<p>Mac OS X�I�y���[�e�B���O�V�X�e���Ɋւ�����̂́F</p><pre class="en">
+<p>Mac OS Xオペレーティングシステムに関するものは：</p><pre class="en">
 blosxom.cgi/computers/operating_systems/apple/mac_os_x/
 </pre>
-<p>���Ԃ������̂ڂ邱�Ƃ��ł���̂ŒT���̌o�H�͑�������܂���B<span class="en">/home/repair</span>��2003�N7���̋L���́F</p><pre class="en">
+<p>時間をさかのぼることができるので探索の経路は多くありません。<span class="en">/home/repair</span>の2003年7月の記事は：</p><pre class="en">
 blosxom.cgi/home/repair/2003/07
 </pre>
-<p><span class="en">/personal/resolutions</span>��2003�N1��1���̋L���́F</p><pre class="en">
+<p><span class="en">/personal/resolutions</span>の2003年1月1日の記事は：</p><pre class="en">
 blosxom.cgi/personal/resolutions/2003/01/01
 </pre>
-<p>�����āA�������A�f�B���N�g���c���[������̂Ǝ��Ԃ������̂ڂ�̂�g�ݍ��킹��ƌ��݂̃f�B���N�g��/�t�H���_�̉��̑S�Ă��{���ł��܂��B���̂��߁A<span class="be">/travel/india/2000/11/</span>�ł�<span class="be">/travel/india</span>�A<span class="be">/travel/india/mumbai</span>�A���̋L����2000�N11���Ɍ��肵�ĉ{�����邱�Ƃ��ł��܂��B</p>
-<h2>�������M</h2><p>�ȏ���ӂ܂���΁A<span class="en">Blosxom</span>�����L������E�F�u���O���������M�ł��邱�Ƃ͌����܂ł�����܂���B���ʂȃO���[�v�K�w���������i�M����<span class="be">/computers</span>�Ŏ���<span class="be">/society</span>�Ƃ��j�A�e�X�l�I�ȃE�F�u���O�������f�B���N�g�����������i����<span class="be">/sam</span>�ŋM����<span class="be">/mira</span>�Ȃǁj����Ηǂ��̂ł��B�܂��͂�����g�ݍ��킹�āA<span class="be">/sam</span>����<span class="be">/sam/society</span>��<span class="be">/sam/cooking</span>�ŏ����āA<span class="be">/mira</span>�����<span class="be">/mira/computers</span>��<span class="be">/mira/travel</span>�������āA���҂�<span class="be">/internet</span>�ŏ����ƌ������Ƃ��ł��܂��B</p><p>�����̎��M�҂�<span class="en">Blosxom</span>�����L����Ƃ������Ƃ͊e�X�̃f�B���N�g������邱�ƂƓ������Ȃ̂ł��B</p>
-<h2>�e�X�̃E�F�u���O�̎Q��</h2><p>�t���p�X�ƃt�@�C�������g���ē���̃E�F�u���O���Q�Ƃ��鎖���ł��܂��B<span class="be">.txt</span>�g���q���D����<a href="doc_users_flavour.html">�t���[�o�[</a>�̂��̂ɕύX����΃E�F�u���O�͂��̃t���[�o�[�e���v���[�g�ŕ\������܂��B�����ɁA<span class="be">/cooking/italian</span>�ɏ����Ă���<span class="en">Bruschetta</span>�̃��V�s�i<span class="be">bruschetta.txt</span>�j������܂��F</p><pre class="en">
+<p>そして、もちろん、ディレクトリツリーを下るのと時間をさかのぼるのを組み合わせると現在のディレクトリ/フォルダの下の全てが閲覧できます。そのため、<span class="be">/travel/india/2000/11/</span>では<span class="be">/travel/india</span>、<span class="be">/travel/india/mumbai</span>、等の記事を2000年11月に限定して閲覧することができます。</p>
+<h2>共同執筆</h2><p>以上をふまえれば、<span class="en">Blosxom</span>を共有したりウェブログを共同執筆できることは言うまでもありません。特別なグループ階層を作ったり（貴方は<span class="be">/computers</span>で私は<span class="be">/society</span>とか）、各々個人的なウェブログを書くディレクトリを作ったり（私は<span class="be">/sam</span>で貴方は<span class="be">/mira</span>など）すれば良いのです。またはそれらを組み合わせて、<span class="be">/sam</span>さんが<span class="be">/sam/society</span>と<span class="be">/sam/cooking</span>で書いて、<span class="be">/mira</span>さんは<span class="be">/mira/computers</span>と<span class="be">/mira/travel</span>を書いて、両者が<span class="be">/internet</span>で書くと言うこともできます。</p><p>複数の執筆者で<span class="en">Blosxom</span>を共有するということは各々のディレクトリを作ることと同じ事なのです。</p>
+<h2>各々のウェブログの参照</h2><p>フルパスとファイル名を使って特定のウェブログを参照する事ができます。<span class="be">.txt</span>拡張子を好きな<a href="doc_users_flavour.html">フレーバー</a>のものに変更すればウェブログはそのフレーバーテンプレートで表示されます。ここに、<span class="be">/cooking/italian</span>に書いている<span class="en">Bruschetta</span>のレシピ（<span class="be">bruschetta.txt</span>）があります：</p><pre class="en">
 blosxom.cgi/cooking/italian/bruschetta.html
 </pre>
-<p>���������̌o���k�́F</p><pre class="en">
+<p>浴室改装の経験談は：</p><pre class="en">
 blosxom.cgi/home/repair/bathroom_remodel.html
-</pre><p class="nextLink"><a href="doc_users_flavour.html" class="bl">�t���[�o�[�e���v���[�g��������...</a></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</pre><p class="nextLink"><a href="doc_users_flavour.html" class="bl">フレーバーテンプレートをいじる...</a></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/doc_users_view.html
+++ b/doc_users_view.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/doc_users_view.html
+++ b/doc_users_view.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::閲覧</title>
 

--- a/downloads.html
+++ b/downloads.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,“ú–{Œê,–|–ó">
-<title>blosxomƒTƒCƒg‚Ì“ú–{Œê–ó::ƒ_ƒEƒ“ƒ[ƒh</title>
+<meta name="keywords" content="blosxom,æ—¥æœ¬èªž,ç¿»è¨³">
+<title>blosxomã‚µã‚¤ãƒˆã®æ—¥æœ¬èªžè¨³::ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,77 +11,77 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::“ú–{Œê–ó</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="ƒtƒŒ[ƒ€">
+<div id="header"><span class="en">blosxom</span>::æ—¥æœ¬èªžè¨³</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="ãƒ•ãƒ¬ãƒ¼ãƒ ">
 <tbody>
 <tr>
 <td id="menu">
-<h4>–|–ó‚É‚Â‚¢‚Ä</h4>
+<h4>ç¿»è¨³ã«ã¤ã„ã¦</h4>
 <ul class="mid">
-<li><a href="index.html" title="‚¨“Ç‚Ý‚­‚¾‚³‚¢">‚¨“Ç‚Ý‚­‚¾‚³‚¢</a></li>
+<li><a href="index.html" title="ãŠèª­ã¿ãã ã•ã„">ãŠèª­ã¿ãã ã•ã„</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom‚É‚Â‚¢‚Ä"><span class="en">Blosxom</span>‚É‚Â‚¢‚Ä</a></li>
-<li><a href="features.html" title="Blosxom‚Ì‹@”\">‹@”\</a></li>
-<li><a href="colophon.html" title="‰œ•t">‰œ•t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ƒjƒ…[ƒX">ƒjƒ…[ƒXi‰pŒêj</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="ƒ[ƒŠƒ“ƒOƒŠƒXƒg">ƒ[ƒŠƒ“ƒOƒŠƒXƒgi‰pŒêj</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="Šñ‘¡">Šñ‘¡i‰pŒêj</a></li>
+<li><a href="about.html" title="Blosxomã«ã¤ã„ã¦"><span class="en">Blosxom</span>ã«ã¤ã„ã¦</a></li>
+<li><a href="features.html" title="Blosxomã®æ©Ÿèƒ½">æ©Ÿèƒ½</a></li>
+<li><a href="colophon.html" title="å¥¥ä»˜">å¥¥ä»˜</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ãƒ‹ãƒ¥ãƒ¼ã‚¹">ãƒ‹ãƒ¥ãƒ¼ã‚¹ï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆ">ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="å¯„è´ˆ">å¯„è´ˆï¼ˆè‹±èªžï¼‰</a></li>
 </ul>
-<h4>ƒ†[ƒUŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>ãƒ¦ãƒ¼ã‚¶å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom‚ÌŠT—v">ŠT—v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom‚ÌƒCƒ“ƒXƒg[ƒ‹">ƒCƒ“ƒXƒg[ƒ‹</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom‚ÌÝ’è">ŠÂ‹«Ý’è</a></li>
-<li><a href="doc_users_blog.html" title="ƒEƒFƒuƒƒO">ƒEƒFƒuƒƒO</a></li>
-<li><a href="doc_users_view.html" title="ƒEƒFƒuƒƒO‚Ì‰{——">‰{——</a></li>
-<li><a href="doc_users_flavour.html" title="ƒtƒŒ[ƒo[">ƒtƒŒ[ƒo[</a></li>
-<li><a href="doc_users_syndicate.html" title="ƒVƒ“ƒWƒP[ƒg">ƒVƒ“ƒWƒP[ƒg</a></li>
-<li><a href="doc_users_plugins.html" title="ƒvƒ‰ƒOƒCƒ“">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="plugin_registry.html" title="ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW">ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW</a></li>
-<li><a href="doc_users_configure_static.html" title="Ã“I•\Ž¦‚ÌÝ’è">Ã“I•\Ž¦‚ÌÝ’è</a></li>
-<li><a href="faq.html" title="—Ç‚­‚ ‚éŽ¿–â"><span class="en">faq</span></a></li>
-<li>Žg—p—á*</li>
+<li><a href="doc_users_overview.html" title="Blosxomã®æ¦‚è¦">æ¦‚è¦</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomã®ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«">ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomã®è¨­å®š">ç’°å¢ƒè¨­å®š</a></li>
+<li><a href="doc_users_blog.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°">ã‚¦ã‚§ãƒ–ãƒ­ã‚°</a></li>
+<li><a href="doc_users_view.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°ã®é–²è¦§">é–²è¦§</a></li>
+<li><a href="doc_users_flavour.html" title="ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼">ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼</a></li>
+<li><a href="doc_users_syndicate.html" title="ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ">ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ</a></li>
+<li><a href="doc_users_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="plugin_registry.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸</a></li>
+<li><a href="doc_users_configure_static.html" title="é™çš„è¡¨ç¤ºã®è¨­å®š">é™çš„è¡¨ç¤ºã®è¨­å®š</a></li>
+<li><a href="faq.html" title="è‰¯ãã‚ã‚‹è³ªå•"><span class="en">faq</span></a></li>
+<li>ä½¿ç”¨ä¾‹*</li>
 </ul>
-<h4>ŠJ”­ŽÒŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>é–‹ç™ºè€…å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="ŠT—vFŠJ”­ŽÒŒü‚¯">ŠT—v</a></li>
-<li><a href="doc_dev_plugins.html" title="ƒvƒ‰ƒOƒCƒ“FŠJ”­ŽÒŒü‚¯">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="doc_dev_plugin_register.html" title="ŠJ”­ŽÒŒü‚¯Fƒvƒ‰ƒOƒCƒ““o˜^">ƒvƒ‰ƒOƒCƒ“‚Ì“o˜^</a></li>
+<li><a href="doc_dev_overview.html" title="æ¦‚è¦ï¼šé–‹ç™ºè€…å‘ã‘">æ¦‚è¦</a></li>
+<li><a href="doc_dev_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ï¼šé–‹ç™ºè€…å‘ã‘">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="doc_dev_plugin_register.html" title="é–‹ç™ºè€…å‘ã‘ï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç™»éŒ²</a></li>
 </ul>
-<h4>ƒ_ƒEƒ“ƒ[ƒh</h4>
+<h4>ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="‘S‚Ä‚Ìl‚Ö">‘S‚Ä‚Ìl‚Ö</a></li>
-<li><a href="license.html" title="ƒ‰ƒCƒZƒ“ƒX">ƒ‰ƒCƒZƒ“ƒX</a></li>
-<li>‹¤“¯§ì*</li>
+<li><a href="downloads.html" title="å…¨ã¦ã®äººã¸">å…¨ã¦ã®äººã¸</a></li>
+<li><a href="license.html" title="ãƒ©ã‚¤ã‚»ãƒ³ã‚¹">ãƒ©ã‚¤ã‚»ãƒ³ã‚¹</a></li>
+<li>å…±åŒåˆ¶ä½œ*</li>
 </ul>
-<p>*ŒöŽ®ƒTƒCƒg‚Å–¢Ž·•M</p>
+<p>*å…¬å¼ã‚µã‚¤ãƒˆã§æœªåŸ·ç­†</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">ƒ_ƒEƒ“ƒ[ƒh</a></h1><p>ŽŽ‚µ‚É<span class="en">Blosxom</span>‚ðŽè‚É“ü‚ê‚æ‚¤‚ÆŒˆ‚ß‚½‚Ì‚Å‚·‚ËBŽ„‚Æ“¯—l‚ÉD‚«‚É‚È‚é‚ÆŽv‚¢‚Ü‚·‚æB</p>
-<h2><a name="macosx" class="anc"><span class="en">Blosxom</span>...</a></h2><p>‹M•û‚ÉÅ‚à‡‚¤<span class="en">Blosxom</span>‚ð‘I‚ñ‚Å‰º‚³‚¢B</p><dl>
+<td id="contents"><h1><a name="top" class="bl">ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰</a></h1><p>è©¦ã—ã«<span class="en">Blosxom</span>ã‚’æ‰‹ã«å…¥ã‚Œã‚ˆã†ã¨æ±ºã‚ãŸã®ã§ã™ã­ã€‚ç§ã¨åŒæ§˜ã«å¥½ãã«ãªã‚‹ã¨æ€ã„ã¾ã™ã‚ˆã€‚</p>
+<h2><a name="macosx" class="anc"><span class="en">Blosxom</span>...</a></h2><p>è²´æ–¹ã«æœ€ã‚‚åˆã†<span class="en">Blosxom</span>ã‚’é¸ã‚“ã§ä¸‹ã•ã„ã€‚</p><dl>
 <dt class="en">Mac OS X</dt>
 <dd>
-<p><span class="en">Mac OS X</span>—p<span class="en">Blosxom</span>ƒCƒ“ƒXƒg[ƒ‰[ƒo[ƒWƒ‡ƒ“2.0<a href="http://www.blosxom.com/downloads.html" class="en">[.pkg.tar.gz]</a>‚ÍŽèì‹Æ‚Å‰½‚çƒCƒ“ƒXƒg[ƒ‹‚µ‚È‚­‚Ä‚à<span class="en">Blosxom</span>‚ðŽè‚É“ü‚ê‚ç‚ê‚é‚à‚Ì‚Å‚·Bƒ}ƒEƒX‚Ì”‰ñ‚ÌƒNƒŠƒbƒN‚Å–Ê“|‚È‚±‚Æ–³‚­A<span class="en">Blosxom</span>–{‘ÌAŠô‚Â‚©‚ÌƒTƒ“ƒvƒ‹ƒtƒŒ[ƒo[AƒhƒLƒ…ƒƒ“ƒg‚»‚µ‚Ä•Ö—˜‚Èƒvƒ‰ƒOƒCƒ“‚ªƒCƒ“ƒXƒg[ƒ‹‚³‚ê‚Ü‚·B‹M•û‚ªƒpƒbƒP[ƒWƒAƒvƒŠƒP[ƒVƒ‡ƒ“‚ðŽg‚¤‚±‚Æ‚ÉŠµ‚ê‚Ä‚¢‚ÄAŽè‚ÁŽæ‚è‘‚­s‚¢‚½‚¢‚Ì‚Å‚ ‚ê‚Î‚«‚Á‚Æ•Ö—˜‚È‚Í‚¸‚Å‚·‚æI</p>
-<p>‚à‚µ‚©‚·‚é‚Æ‹M•û‚ÍŽ©•ª‚Å‚â‚è‚½‚¢l‚ÅA<span class="en">Blosxom</span>‚ª‚Ç‚¤“®‚­‚©‚¢‚¶‚è‚½‚¢‚©‚à’m‚ê‚Ü‚¹‚ñB‚È‚çAƒXƒNƒŠƒvƒg‚ðƒ_ƒEƒ“ƒ[ƒh‚µ‚Ä“KØ‚ÈƒfƒBƒŒƒNƒgƒŠ‚ðì‚èAÝ’è‚ð‚¢‚¶‚è“|‚µ‚Ä‚à—Ç‚¢‚Å‚µ‚å‚¤B</p>
+<p><span class="en">Mac OS X</span>ç”¨<span class="en">Blosxom</span>ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ©ãƒ¼ãƒãƒ¼ã‚¸ãƒ§ãƒ³2.0<a href="http://www.blosxom.com/downloads.html" class="en">[.pkg.tar.gz]</a>ã¯æ‰‹ä½œæ¥­ã§ä½•ã‚‰ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã—ãªãã¦ã‚‚<span class="en">Blosxom</span>ã‚’æ‰‹ã«å…¥ã‚Œã‚‰ã‚Œã‚‹ã‚‚ã®ã§ã™ã€‚ãƒžã‚¦ã‚¹ã®æ•°å›žã®ã‚¯ãƒªãƒƒã‚¯ã§é¢å€’ãªã“ã¨ç„¡ãã€<span class="en">Blosxom</span>æœ¬ä½“ã€å¹¾ã¤ã‹ã®ã‚µãƒ³ãƒ—ãƒ«ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼ã€ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆãã—ã¦ä¾¿åˆ©ãªãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãŒã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã•ã‚Œã¾ã™ã€‚è²´æ–¹ãŒãƒ‘ãƒƒã‚±ãƒ¼ã‚¸ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³ã‚’ä½¿ã†ã“ã¨ã«æ…£ã‚Œã¦ã„ã¦ã€æ‰‹ã£å–ã‚Šæ—©ãè¡Œã„ãŸã„ã®ã§ã‚ã‚Œã°ãã£ã¨ä¾¿åˆ©ãªã¯ãšã§ã™ã‚ˆï¼</p>
+<p>ã‚‚ã—ã‹ã™ã‚‹ã¨è²´æ–¹ã¯è‡ªåˆ†ã§ã‚„ã‚ŠãŸã„äººã§ã€<span class="en">Blosxom</span>ãŒã©ã†å‹•ãã‹ã„ã˜ã‚ŠãŸã„ã‹ã‚‚çŸ¥ã‚Œã¾ã›ã‚“ã€‚ãªã‚‰ã€ã‚¹ã‚¯ãƒªãƒ—ãƒˆã‚’ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰ã—ã¦é©åˆ‡ãªãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªã‚’ä½œã‚Šã€è¨­å®šã‚’ã„ã˜ã‚Šå€’ã—ã¦ã‚‚è‰¯ã„ã§ã—ã‚‡ã†ã€‚</p>
 </dd>
 <dt class="en">Windows 2000/XP</dt>
 <dd>
-<p><span class="en">Windows 2000/XP</span>—p<span class="en">Blosxom</span>ƒCƒ“ƒXƒg[ƒ‰[‚ÍŒ»Ý€”õ’†‚Å‚·Bí‚É<span class="en">Blosxom</span>ƒjƒ…[ƒX‚ðƒ`ƒFƒbƒN‚µ‚Ä‰º‚³‚¢B‚à‚¿‚ë‚ñƒ[ƒŠƒ“ƒOƒŠƒXƒg‚àB‚Ü‚¸‚Í&quot;‘S‚Ä‚Ìl‚Ö&quot;ƒo[ƒWƒ‡ƒ“‚ðŽg‚Á‚Ä‰º‚³‚¢B</p>
+<p><span class="en">Windows 2000/XP</span>ç”¨<span class="en">Blosxom</span>ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ©ãƒ¼ã¯ç¾åœ¨æº–å‚™ä¸­ã§ã™ã€‚å¸¸ã«<span class="en">Blosxom</span>ãƒ‹ãƒ¥ãƒ¼ã‚¹ã‚’ãƒã‚§ãƒƒã‚¯ã—ã¦ä¸‹ã•ã„ã€‚ã‚‚ã¡ã‚ã‚“ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆã‚‚ã€‚ã¾ãšã¯&quot;å…¨ã¦ã®äººã¸&quot;ãƒãƒ¼ã‚¸ãƒ§ãƒ³ã‚’ä½¿ã£ã¦ä¸‹ã•ã„ã€‚</p>
 </dd>
-<dt>‘S‚Ä‚Ìl‚Ö</dt>
+<dt>å…¨ã¦ã®äººã¸</dt>
 <dd>
-<p><span class="en">Blosxom</span>ƒo[ƒWƒ‡ƒ“2.0<a href="http://www.blosxom.com/downloads.html" class="en">[ZIP]</a>‚Í‚ ‚éêŠ‚Öƒhƒƒbƒv‚µ‚Ä­‚µŠÂ‹«Ý’è‚ð‚·‚é‚¾‚¯‚ÌŠÈ’P‚È<span class="en">CGI</span>ƒXƒNƒŠƒvƒg‚Å‚·B“üŽè‚µ‚½‚çƒCƒ“ƒXƒg[ƒ‹‚Ìà–¾‚ð“Ç‚ñ‚Å‰º‚³‚¢B</p>
+<p><span class="en">Blosxom</span>ãƒãƒ¼ã‚¸ãƒ§ãƒ³2.0<a href="http://www.blosxom.com/downloads.html" class="en">[ZIP]</a>ã¯ã‚ã‚‹å ´æ‰€ã¸ãƒ‰ãƒ­ãƒƒãƒ—ã—ã¦å°‘ã—ç’°å¢ƒè¨­å®šã‚’ã™ã‚‹ã ã‘ã®ç°¡å˜ãª<span class="en">CGI</span>ã‚¹ã‚¯ãƒªãƒ—ãƒˆã§ã™ã€‚å…¥æ‰‹ã—ãŸã‚‰ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«ã®èª¬æ˜Žã‚’èª­ã‚“ã§ä¸‹ã•ã„ã€‚</p>
 </dd>
-</dl><p class="nextLink"><a href="doc_users_install_dynamic.html" class="bl">ƒCƒ“ƒXƒg[ƒ‹...</a></p>
-<h3>ƒtƒŒ[ƒo[...</h3><p><span class="en">Blosxom</span>‚ÌƒtƒŒ[ƒo[ƒeƒ“ƒvƒŒ[ƒg‚Í‹M•û‚Ì<span class="en">Blosxom</span>ƒEƒFƒuƒƒO‚ÌŒ©‚½–Ú‚ðŠ®‘S‚ÉƒJƒXƒ^ƒ}ƒCƒY‚·‚é‚à‚Ì‚Å‚·B<a href="doc_users_flavour.html">ƒtƒŒ[ƒo[‚ÌÚ×</a>‚ðƒIƒ“ƒ‰ƒCƒ“‚Å“Ç‚Þ‚±‚Æ‚ª‚Å‚«‚Ü‚·B</p><ul>
+</dl><p class="nextLink"><a href="doc_users_install_dynamic.html" class="bl">ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«...</a></p>
+<h3>ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼...</h3><p><span class="en">Blosxom</span>ã®ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆã¯è²´æ–¹ã®<span class="en">Blosxom</span>ã‚¦ã‚§ãƒ–ãƒ­ã‚°ã®è¦‹ãŸç›®ã‚’å®Œå…¨ã«ã‚«ã‚¹ã‚¿ãƒžã‚¤ã‚ºã™ã‚‹ã‚‚ã®ã§ã™ã€‚<a href="doc_users_flavour.html">ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼ã®è©³ç´°</a>ã‚’ã‚ªãƒ³ãƒ©ã‚¤ãƒ³ã§èª­ã‚€ã“ã¨ãŒã§ãã¾ã™ã€‚</p><ul>
 <li>
-<p><span class="en">Blosxom Flavour Sampler [ZIP]</span>‚ÍƒTƒ“ƒvƒ‹‚Ì<span class="en">Blosxom</span>ƒtƒŒ[ƒo[‚ÌƒRƒŒƒNƒVƒ‡ƒ“‚Å“Ë•t‚¢‚½‚è‚Æ‚©FX‚Å‚«‚Ü‚·B‚±‚ê‚ð‰ð“€‚µ‚Ä‹M•û‚Ì<span class="en">Blosxom</span>‚Ì<a href="doc_users_configure.html">ƒf[ƒ^ƒfƒBƒŒƒNƒgƒŠ</a>‚Éƒhƒ‰ƒbƒO‚µ‚Ä‰º‚³‚¢B</p>
+<p><span class="en">Blosxom Flavour Sampler [ZIP]</span>ã¯ã‚µãƒ³ãƒ—ãƒ«ã®<span class="en">Blosxom</span>ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼ã®ã‚³ãƒ¬ã‚¯ã‚·ãƒ§ãƒ³ã§çªä»˜ã„ãŸã‚Šã¨ã‹è‰²ã€…ã§ãã¾ã™ã€‚ã“ã‚Œã‚’è§£å‡ã—ã¦è²´æ–¹ã®<span class="en">Blosxom</span>ã®<a href="doc_users_configure.html">ãƒ‡ãƒ¼ã‚¿ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒª</a>ã«ãƒ‰ãƒ©ãƒƒã‚°ã—ã¦ä¸‹ã•ã„ã€‚</p>
 </li>
 </ul>
-<h3>ƒvƒ‰ƒOƒCƒ“...</h3><p><span class="en">Blosxom</span>‚ðŠg’£‚µ‚½‚è“‡‚µ‚½‚è‚Å‚«‚é‚½‚­‚³‚ñ‚ÌƒT[ƒhƒp[ƒeƒB[»ƒvƒ‰ƒOƒCƒ“‚ª‚ ‚è‚Ü‚·B<a href="plugin_registry.html">ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW</a>‚Å‘S‚Ä‚ðŒ©‚Â‚¯‚é‚±‚Æ‚ª‚Å‚«‚Ü‚·B</p><p class="nextLink"><a href="#top">[ƒy[ƒW‚Ìæ“ª‚Ö–ß‚é]</a></p></td>
+<h3>ãƒ—ãƒ©ã‚°ã‚¤ãƒ³...</h3><p><span class="en">Blosxom</span>ã‚’æ‹¡å¼µã—ãŸã‚Šçµ±åˆã—ãŸã‚Šã§ãã‚‹ãŸãã•ã‚“ã®ã‚µãƒ¼ãƒ‰ãƒ‘ãƒ¼ãƒ†ã‚£ãƒ¼è£½ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ãŒã‚ã‚Šã¾ã™ã€‚<a href="plugin_registry.html">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸</a>ã§å…¨ã¦ã‚’è¦‹ã¤ã‘ã‚‹ã“ã¨ãŒã§ãã¾ã™ã€‚</p><p class="nextLink"><a href="#top">[ãƒšãƒ¼ã‚¸ã®å…ˆé ­ã¸æˆ»ã‚‹]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/downloads.html
+++ b/downloads.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/downloads.html
+++ b/downloads.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::ダウンロード</title>
 

--- a/faq.html
+++ b/faq.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ</title>
 

--- a/faq.html
+++ b/faq.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq.html
+++ b/faq.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,83 +11,83 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><p>�����ɂ�<span class="en">TIPS</span>�A�g���b�N�A�e�N�j�b�N���A�M���̂悤��<span class="en">Blosxom</span>���[�U�ɂ���ďW�߂�ꂽ��񂪂���܂��B</p><p> �R�~���j�e�B�Ƌ��L�ł��鉽���������Ă���H�@<span class="en">FAQ</span>�ɒǉ����ĉ������I</p><h2 class="en">/faq</h2><ul class="mid">
-<li><a href="faq_configure_permalinks.html"><span class="en">Blosxom</span>��<span class="en">permalinks</span>�̐ݒ���@��?</a></li>
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><p>ここには<span class="en">TIPS</span>、トリック、テクニック等、貴方のような<span class="en">Blosxom</span>ユーザによって集められた情報があります。</p><p> コミュニティと共有できる何かを持っている？　<span class="en">FAQ</span>に追加して下さい！</p><h2 class="en">/faq</h2><ul class="mid">
+<li><a href="faq_configure_permalinks.html"><span class="en">Blosxom</span>の<span class="en">permalinks</span>の設定方法は?</a></li>
 </ul><h2 class="en">/faq/cgi</h2><ul class="mid">
-<li><span class="en"><a href="faq_cgi_hide_url_bit.html">URL</a></span><a href="faq_cgi_hide_url_bit.html">����<span class="en">/cgi-bin/blosxom.cgi</span>���ǂ���������B���܂����H</a></li>
+<li><span class="en"><a href="faq_cgi_hide_url_bit.html">URL</a></span><a href="faq_cgi_hide_url_bit.html">から<span class="en">/cgi-bin/blosxom.cgi</span>をどうやったか隠せますか？</a></li>
 </ul><h2 class="en">/faq/directories</h2><ul class="mid">
-<li><a href="faq_directories_numeric.html">�f�B���N�g�����𐔎��Ŏn�߂邱�Ƃ͂ł��܂���?</a></li>
+<li><a href="faq_directories_numeric.html">ディレクトリ名を数字で始めることはできますか?</a></li>
 </ul><h2 class="en">/faq/display</h2><ul class="mid">
-<li><a href="faq_include_function_individual.html">�e���O�i<span class="en">permalinks</span>�j�y�[�W�݂̂ɑ����̋@�\�ǉ���������@��?</a></li>
+<li><a href="faq_include_function_individual.html">各ログ（<span class="en">permalinks</span>）ページのみに多少の機能追加を入れる方法は?</a></li>
 </ul><h2 class="en">/faq/general</h2><ul class="mid">
-<li><span class="en"><a href="faq_build_a_section_like.html">Rael</a></span><a href="faq_build_a_section_like.html">����̃v���O�C���f�B���N�g����<span class="en">FAQ</span>�̂悤�ȃZ�N�V�������ǂ����������܂����H</a></li>
-<li><a href="faq_only_showing_the_default.html"> �ǂ�����<span class="en">Blosxom</span>�͎��̃E�F�u���O�ł͂Ȃ��ĕW���̃w�b�_�ƃt�b�^��\������̂ł����H</a></li>
+<li><span class="en"><a href="faq_build_a_section_like.html">Rael</a></span><a href="faq_build_a_section_like.html">さんのプラグインディレクトリや<span class="en">FAQ</span>のようなセクションをどうやったら作れますか？</a></li>
+<li><a href="faq_only_showing_the_default.html"> どうして<span class="en">Blosxom</span>は私のウェブログではなくて標準のヘッダとフッタを表示するのですか？</a></li>
 </ul><h2 class="en"> /faq/header/encoding</h2><ul class="mid">
-<li><a href="faq_specify_encoding.html">����̃t���[�o�[�ŕ����G���R�[�h����肷��ɂ͂ǂ�����̂ł����H</a></li>
+<li><a href="faq_specify_encoding.html">特定のフレーバーで文字エンコードを特定するにはどうするのですか？</a></li>
 </ul><h2 class="en"> /faq/install</h2><ul class="mid">
-<li><a href="faq_datadir_correct_value.html">���̃T�C�g��<span class="en">$datadir</span>�ɑ΂��鐳�m�Ȓl���ǂ�����Ċm�F����΂悢�̂ł����H</a></li>
+<li><a href="faq_datadir_correct_value.html">私のサイトで<span class="en">$datadir</span>に対する正確な値をどうやって確認すればよいのですか？</a></li>
 </ul><h2 class="en"> /faq/operating_system/windows/iis</h2><ul class="mid">
-<li><span class="en"><a href="faq_iis_path_info_issue.html">IIS</a></span><a href="faq_iis_path_info_issue.html">��<span class="en">PATH_INFO</span>�̖��ɂ��ւ�炸<span class="en">Blosxom</span>�𓮍삳����ɂ͂ǂ�����Ηǂ��̂ł����H</a></li>
+<li><span class="en"><a href="faq_iis_path_info_issue.html">IIS</a></span><a href="faq_iis_path_info_issue.html">の<span class="en">PATH_INFO</span>の問題にも関わらず<span class="en">Blosxom</span>を動作させるにはどうすれば良いのですか？</a></li>
 </ul><h2 class="en"> /faq/plugins</h2><ul class="mid">
-<li><a href="faq_manipulate_order_plugin.html">�v���O�����I�Ƀv���O�C���̎��s�����𑀍삷�邱�Ƃ͂ł��܂���?</a></li>
-<li><a href="faq_particular_order_plugin.html">����̏��ԂŃv���O�C�������s������ɂ�?</a></li>
-<li><a href="faq_meta_data.html">�ǂ�����ă��O�t�@�C���̓��t�⑼�̃��^�f�[�^�����o���̂ł���?</a> </li>
+<li><a href="faq_manipulate_order_plugin.html">プログラム的にプラグインの実行順序を操作することはできますか?</a></li>
+<li><a href="faq_particular_order_plugin.html">特定の順番でプラグインを実行させるには?</a></li>
+<li><a href="faq_meta_data.html">どうやってログファイルの日付や他のメタデータを取り出すのですか?</a> </li>
 </ul>
 <h2 class="en"> /faq/posting</h2><ul class="mid">
-<li><a href="faq_post_by_email.html">���O�����[���ō쐬���邱�Ƃ͂ł��܂���?</a></li>
+<li><a href="faq_post_by_email.html">ログをメールで作成することはできますか?</a></li>
 </ul>
 <h2 class="en"> /faq/upgrade</h2><ul class="mid">
-<li><a href="faq_changed_rss.html"><span class="en">Blosxom</span>��O�̃o�[�W�����i<span class="en">0+4i</span>�������͂����ƑO�j����A�b�v�O���[�h���܂����B<span class="en">RSS</span>�ɉ��������Ă���̂ł����H</a></li>
-</ul><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<li><a href="faq_changed_rss.html"><span class="en">Blosxom</span>を前のバージョン（<span class="en">0+4i</span>もしくはもっと前）からアップグレードしました。<span class="en">RSS</span>に何が生じているのですか？</a></li>
+</ul><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_build_a_section_like.html
+++ b/faq_build_a_section_like.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - Rael����̃v���O�C���f�B���N�g����FAQ�̂悤�ȃZ�N�V�������ǂ����������܂���?</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - RaelさんのプラグインディレクトリやFAQのようなセクションをどうやったら作れますか?</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,64 +11,64 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">Rael</span>����̃v���O�C���f�B���N�g����<span class="en">FAQ</span>�̂悤�ȃZ�N�V�������ǂ����������܂����H</h2>
-<p>�v���O�C���f�B���N�g���̂悤�ȃZ�N�V���������ۂɍŏ��ɒm��Ȃ���΂Ȃ�Ȃ����́A����̃v���O�C����T�d�Ɉ����K�v������ƌ������ƂƁA�t���[�o�[�Ɋւ��鑽���̒m���ł��B</p><p>���̃v���O�C�����K�v�ɂȂ�ł��傤�F <span class="en">'config'</span>�A <span class="en">'crop_path'</span>�A <span class="en">'sort_by_path'</span></p><p><span class="en">'crop_path'</span>��<span class="en">'sort_by_path'</span>�̓t�@�C�����̌��<span class="en">'_'</span>��t���Ė����ɂ��Ă����܂��B�e�v���O�C���̎g�����Ɋւ��Ă̓v���O�C���t�@�C���̌��<span class="en">perldoc</span>���m�F���ĉ������B�����Ďn�߂�ɂ������Ċ֌W�̂���ϐ����m�F���ĉ������i�R�}���h���C����<span class="en">perldoc</span> �v���O�C���� �Ɠ��͂��ĉ������j�B</p><p>���ɕK�v�ɂȂ�̂̓f�B���N�g���\�����\�z���邱�Ƃł��B�e�J�e�S���ɑ΂��Đe�f�B���N�g���Ǝq�f�B���N�g�����K�v�ɂȂ�܂��B���̂��߁A�Ⴆ��Rael�̃v���O�C���f�B���N�g���ɂ�<span class="en">'plugins'</span>�ƌ����e�f�B���N�g����<span class="en">'archives'</span>�A<span class="en">'author</span>'�A<span class="en">'browser'</span>�A<span class="en">'calendar'</span>���̎q�f�B���N�g��������܂��B</p><p>�����ŁA�\�����邽�߂̃t���[�o�[���K�v�ɂȂ�܂��B�M���̕W���̃X�^�C������S�Ẵt���[�o�[���R�s�[���Đe�f�B���N�g���ɂ����A�S�Ẵt�@�C�����̃T�t�B�b�N�X�������ɕύX���ĉ������B���̓T�t�B�b�N�X�Ƃ���<span class="en">'.w'</span>���g���܂����B�n�߂̃y�[�W�ŋL����\������̂ɕW���̃t���[�o�[���g��Ȃ��悤�ɂ��邽�߂ɂ��̍�Ƃ��K�v�ɂȂ�܂��B�ύX���Ȃ��Ă͂Ȃ�Ȃ��B��̃t���[�o�[�t�@�C����<span class="en">'date.w'</span>��<span class="en">'story.w'</span>�ŁA�p�X�݂̂�\�����A�����ăJ�e�S���[�֍s�������N��񋟂���悤�ɂ��܂��B����<span class="en">date.w</span>�͈ȉ��̒ʂ�ł��F</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">Rael</span>さんのプラグインディレクトリや<span class="en">FAQ</span>のようなセクションをどうやったら作れますか？</h2>
+<p>プラグインディレクトリのようなセクションを作る際に最初に知らなければならない事は、幾つかのプラグインを慎重に扱う必要があると言うことと、フレーバーに関する多少の知識です。</p><p>次のプラグインが必要になるでしょう： <span class="en">'config'</span>、 <span class="en">'crop_path'</span>、 <span class="en">'sort_by_path'</span></p><p><span class="en">'crop_path'</span>と<span class="en">'sort_by_path'</span>はファイル名の後に<span class="en">'_'</span>を付けて無効にしておきます。各プラグインの使い方に関してはプラグインファイルの後の<span class="en">perldoc</span>を確認して下さい。そして始めるにあたって関係のある変数を確認して下さい（コマンドラインで<span class="en">perldoc</span> プラグイン名 と入力して下さい）。</p><p>次に必要になるのはディレクトリ構造を構築することです。各カテゴリに対して親ディレクトリと子ディレクトリが必要になります。そのため、例えばRaelのプラグインディレクトリには<span class="en">'plugins'</span>と言う親ディレクトリと<span class="en">'archives'</span>、<span class="en">'author</span>'、<span class="en">'browser'</span>、<span class="en">'calendar'</span>等の子ディレクトリがあります。</p><p>ここで、表示するためのフレーバーが必要になります。貴方の標準のスタイルから全てのフレーバーをコピーして親ディレクトリにおき、全てのファイル名のサフィックスを何かに変更して下さい。私はサフィックスとして<span class="en">'.w'</span>を使いました。始めのページで記事を表示するのに標準のフレーバーを使わないようにするためにこの作業が必要になります。変更しなくてはならない唯一のフレーバーファイルは<span class="en">'date.w'</span>と<span class="en">'story.w'</span>で、パスのみを表示し、そしてカテゴリーへ行くリンクを提供するようにします。私の<span class="en">date.w</span>は以下の通りです：</p><pre class="en">
 &lt;span class=&quot;category&quot;&gt;
 &lt;p style=&quot;margin-left: 0px;&quot;&gt;
 &lt;a href=&quot;$url$path&quot;&gt;$crop_path::path&lt;/a&gt;
 &lt;/p&gt;
 &lt;/span&gt;
 </pre>
-<p><span class="en">story.w</span>�́F</p><pre class="en">&lt;code&gt;
+<p><span class="en">story.w</span>は：</p><pre class="en">&lt;code&gt;
 &lt;span class=&quot;category-item&quot;&gt;
 &lt;p style=&quot;margin-left: 12px;&quot;&gt;
 &lt;b&gt;$title&lt;/b&gt;
@@ -76,17 +76,17 @@ $body
 &lt;a href=&quot;$url$path/$fn.writeback&quot; class=&quot;orangelink&quot;&gt;
 more&lt;/a&gt;
 </pre>
-<p>�^�C�g���𑾎��ɂ��A�L���̎c������̒�����ɒu���A�����Ă��̒�����ɕԐM�y�[�W�ւ̃����N��u���悤�ɂ��Ă��܂��B</p><p>�Ō�ɁA<span class="en">config</span>�t�@�C���������܂��B���̗�ł��F</p><pre class="en">
+<p>タイトルを太字にし、記事の残りをこの直ぐ後に置き、そしてその直ぐ後に返信ページへのリンクを置くようにしています。</p><p>最後に、<span class="en">config</span>ファイルを書きます。私の例です：</p><pre class="en">
 $blosxom::plugins{'sort_by_path'} = 1;
 $blosxom::flavour = &quot;w&quot;;
 $blosxom::plugins{'crop_path'} = 1;
 $blosxom::num_entries = 999;
-</pre><p><span class="en">'sort_path'</span>��L���ɂ��A���Ƀt���[�o�[��<span class="en">'w'</span>�ɐݒ肵�A�J�e�S�����q�̖��O�̂ݎ��悤��<span class="en">'crop_path'</span>��L���ɂ��A�����čŌ��<span class="en">num_entries</span>���\���ɑ傫�Ȓl�ɐݒ肵�Ă��܂��B����<span class="en">config</span>�t�@�C���͐e�f�B���N�g���Ɗe�q�f�B���N�g���ɒu���܂��B</p><p>�ȏ�ŃJ�e�S���ŕ��בւ���ꂽ�y�[�W���\������܂��B</p>
+</pre><p><span class="en">'sort_path'</span>を有効にし、次にフレーバーを<span class="en">'w'</span>に設定し、カテゴリが子の名前のみ持つように<span class="en">'crop_path'</span>を有効にし、そして最後に<span class="en">num_entries</span>を十分に大きな値に設定しています。この<span class="en">config</span>ファイルは親ディレクトリと各子ディレクトリに置きます。</p><p>以上でカテゴリで並べ替えられたページが表示されます。</p>
 <div id="author">
 <p class="en">Author: Tony Williams<br>
 Category: /faq/general<br>
 Date: 2003-07-27</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_build_a_section_like.html
+++ b/faq_build_a_section_like.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_build_a_section_like.html
+++ b/faq_build_a_section_like.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - RaelさんのプラグインディレクトリやFAQのようなセクションをどうやったら作れますか?</title>
 

--- a/faq_cgi_hide_url_bit.html
+++ b/faq_cgi_hide_url_bit.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - URL����/cgi-bin/blosxom.cgi���ǂ��������B���܂���?</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - URLから/cgi-bin/blosxom.cgiをどうやったら隠せますか?</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,61 +11,61 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">URL</span>����<span class="en">/cgi-bin/blosxom.cgi</span>���ǂ���������B���܂����H</h2>
-<p><span class="en">URL</span>��<span class="en">/cgi-bin/blosxom.cgi</span>�����������Ȃ��ꍇ�A����̕��@������܂�...</p>
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">URL</span>から<span class="en">/cgi-bin/blosxom.cgi</span>をどうやったか隠せますか？</h2>
+<p><span class="en">URL</span>に<span class="en">/cgi-bin/blosxom.cgi</span>を見せたくない場合、幾つかの方法があります...</p>
 <ul>
 <li>
-<p><span class="en">cgi-bin</span>�f�B���N�g���ł͖����f�B���N�g����<span class="en">CGI</span>�X�N���v�g�����s���鎖���\�ł���΁A<strong class="se">weblog</strong>��<strong class="se">blog</strong>�܂��͋M���̍D���ȃf�B���N�g����<strong class="se">blosxom.cgi</strong>��u���ĉ������B�������邱�ƂŁA<strong class="se">/weblog/blosxom.cgi</strong>�̂悤�Ȍ`�ŃA�N�Z�X�ł���悤�ɂȂ�܂��B�f�B���N�g���͋M�����I�񂾏ꏊ�ɂȂ�܂��B</p>
-<p><span class="en">index.cgi</span>�ɖ��O��ς��邱�Ƃ�<span class="en">CGI</span>���B�������ł��邩������܂���B���̏ꍇ��<strong class="se">/weblog</strong>�̂悤�Ȍ`�̃T�u�f�B���N�g���ŃE�F�u���O�Ɉړ��ł��܂��B����̓E�F�u�T�[�o�[��<strong class="se">index.html</strong>�Ɠ��l��<strong class="se">index.cgi</strong>��<span class="en">DirectoryIndex</span>�f�B���N�e�B�u�ɐݒ肳��Ă���ꍇ�ɓ��삵�܂��B���삷��ꍇ�ɂ͖��O��ύX����<strong class="se">index.cgi</strong>�i�ȑO��<strong class="se">blosxom.cgi</strong>���������́j����<span class="en">$url</span>��ύX���邱�Ƃ�Y��Ȃ��ŉ������B��F</p>
+<p><span class="en">cgi-bin</span>ディレクトリでは無いディレクトリで<span class="en">CGI</span>スクリプトを実行する事が可能であれば、<strong class="se">weblog</strong>や<strong class="se">blog</strong>または貴方の好きなディレクトリに<strong class="se">blosxom.cgi</strong>を置いて下さい。こうすることで、<strong class="se">/weblog/blosxom.cgi</strong>のような形でアクセスできるようになります。ディレクトリは貴方が選んだ場所になります。</p>
+<p><span class="en">index.cgi</span>に名前を変えることで<span class="en">CGI</span>を隠す事ができるかもしれません。この場合は<strong class="se">/weblog</strong>のような形のサブディレクトリでウェブログに移動できます。これはウェブサーバーが<strong class="se">index.html</strong>と同様に<strong class="se">index.cgi</strong>が<span class="en">DirectoryIndex</span>ディレクティブに設定されている場合に動作します。動作する場合には名前を変更した<strong class="se">index.cgi</strong>（以前は<strong class="se">blosxom.cgi</strong>だったもの）内で<span class="en">$url</span>を変更することを忘れないで下さい。例：</p>
 <pre class="en">
 # What's my preferred base URL for this blog (leave blank for automatic)?
 my $url = &quot;http://www.example/weblog&quot;;
@@ -73,38 +73,38 @@ my $url = &quot;http://www.example/weblog&quot;;
 </li>
 
 <li>
-<p>�E�F�u�T�[�o�[�̊��t�@�C���𑀍�ł���i<span class="en">Apache</span>�ł�<strong class="se">httpd.conf</strong>�j�A�܂��̓��[�J����<span class="en">sysadmin</span>�ɃA�N�Z�X�ł���A�܂���<span class="en">ISP</span>���ύX�̗]�n��^���Ă���ꍇ�ɂ́A�X�N���v�g�ɑ΂��ē����<span class="en">URL</span>�̃G�C���A�X���쐬����̂��ł��ȒP�ȕ��@�Ɏv���܂��B�Ⴆ�΁A<span class="en">Mac OS X</span>�ł͈ȉ���<span class="en">/etc/httpd/httpd.conf</span>�ɒǉ����܂��B</p>
+<p>ウェブサーバーの環境ファイルを操作できる（<span class="en">Apache</span>では<strong class="se">httpd.conf</strong>）、またはローカルの<span class="en">sysadmin</span>にアクセスできる、または<span class="en">ISP</span>が変更の余地を与えている場合には、スクリプトに対して特定の<span class="en">URL</span>のエイリアスを作成するのが最も簡単な方法に思えます。例えば、<span class="en">Mac OS X</span>では以下を<span class="en">/etc/httpd/httpd.conf</span>に追加します。</p>
 <pre class="en">
 ScriptAlias / /Library/WebServer/CGI-Executables/blosxom.cgi
 </pre>
 </li>
 
 <li>
-<p>�E�F�u�T�[�o�[�̊��t�@�C���𑀍�ł��Ȃ��A�܂���<span class="en">sysadmin/ISP</span>���ύX�̗]�n��^���Ă��Ȃ��ꍇ�A<span class="en">mod_rewite</span>���g����̂ł���Ζ]�ގ����ł��܂��B����͑�ϋ��͂�<span class="en">Apache</span>�̃��W���[����<span class="en">URL</span>�̕ύX�������蓙�A�����̎����ł�����̂ł��B</p>
+<p>ウェブサーバーの環境ファイルを操作できない、または<span class="en">sysadmin/ISP</span>が変更の余地を与えていない場合、<span class="en">mod_rewite</span>が使えるのであれば望む事ができます。これは大変強力な<span class="en">Apache</span>のモジュールで<span class="en">URL</span>の変更をしたり等、多くの事ができるものです。</p>
 
 <ol>
 <li>
-<p><strong class="se">cgi-bin</strong>�f�B���N�g����<strong class="se">blosxom.cgi</strong>�X�N���v�g��u���܂� --���̃f�B���N�g���̓X�N���v�g�̎��s��������Ă���ꏊ�ł��B</p>
+<p><strong class="se">cgi-bin</strong>ディレクトリに<strong class="se">blosxom.cgi</strong>スクリプトを置きます --このディレクトリはスクリプトの実行が許可されている場所です。</p>
 </li>
 <li>
-<p>�M���̃h�L�������g�f�B���N�g��--�E�F�u�A�N�Z�X�\�ȑS�Ă�<span class="en">HTML</span>�t�@�C�����u����Ă���ꏊ��<strong class="se">.htaccess</strong>�ƌ������O�̒ʏ�̃e�L�X�g�t�@�C�����쐬���܂��B<strong class="se">.htaccess</strong>�t�@�C���͈ȉ��̂悤�Ȋ����ɂȂ�܂��F</p>
+<p>貴方のドキュメントディレクトリ--ウェブアクセス可能な全ての<span class="en">HTML</span>ファイルが置かれている場所に<strong class="se">.htaccess</strong>と言う名前の通常のテキストファイルを作成します。<strong class="se">.htaccess</strong>ファイルは以下のような感じになります：</p>
 <pre class="en">
 RewriteEngine on
 RewriteRule ^weblog/?(.*)$ /cgi-bin/blosxom.cgi/$1
 </pre>
-<p>������<span class="be">weblog</span>�͋M���̃E�F�u���O��u���ꏊ�Łi���̏ꍇ�A<strong class="se">/weblog</strong>�j�A<span class="be">cgi-bin</span>�̓u���E�U���Ăяo���X�N���v�g������ꏊ�ł��B</p>
+<p>ここで<span class="be">weblog</span>は貴方のウェブログを置く場所で（この場合、<strong class="se">/weblog</strong>）、<span class="be">cgi-bin</span>はブラウザが呼び出すスクリプトがある場所です。</p>
 </li>
 <li>
-<p>�M���̑S�Ă̋L���A�t���[�o�[�t�@�C���A�X�^�C���V�[�g����<span class="en">Blosxom</span>��<a href="doc_users_install_dynamic.html" class="en">$datadir</a>�ɒu���悤�ɂ��܂�</p>
-<p><span class="en">/weblog</span>�̂悤��&quot;�T�u�f�B���N�g��&quot;�̌`�ł͖����� <span class="en">/</span> �Œ񋟂���悤�ɂ��鑼�̕��@������܂��B����͂ނ��댫���A��������������@�ŁA���݂��Ȃ��t�@�C����f�B���N�g�����w�肷��ƃG���[<span class="en">404</span>���Ԃ�܂��B<span class="en">;-)</span>�B�P����<span class="en">.htaccess</span>�ƈꏏ��<span class="en">Blosxom</span>���h�L�������g�f�B���N�g���ɒu���Ηǂ��ł��F</p>
+<p>貴方の全ての記事、フレーバーファイル、スタイルシート等は<span class="en">Blosxom</span>の<a href="doc_users_install_dynamic.html" class="en">$datadir</a>に置くようにします</p>
+<p><span class="en">/weblog</span>のような&quot;サブディレクトリ&quot;の形では無くて <span class="en">/</span> で提供するようにする他の方法があります。これはむしろ賢く、現実味がある方法で、存在しないファイルやディレクトリを指定するとエラー<span class="en">404</span>が返ります。<span class="en">;-)</span>。単純に<span class="en">.htaccess</span>と一緒に<span class="en">Blosxom</span>をドキュメントディレクトリに置けば良いです：</p>
 <pre class="en">
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ blosxom.cgi/$1 [L,QSA]
 </pre>
-<p>�u���E�U�ő��݂��Ȃ�<strong class="se">/something</strong>�f�B���N�g���ɃA�N�Z�X����ƁA<span class="en">Blosxom</span>�͒��ɓ����Ă��܂��B<br>
-����ŁA<strong class="se">/weblog</strong>�Ŏn�܂�<span class="en">URL</span>��<span class="en">rewite</span>�G���W���ɂƂ炦���A<strong class="se">blosxom.cgi</strong>�ɓn����܂��B<strong class="se">/weblog</strong>�i�����Ēǉ���<strong class="se">/</strong>�j�̌��<span class="en">path_info</span>�ɏ]����<span class="en">CGI</span>�ɓn����܂��B<br>
-<strong class="se">/weblog</strong>�Ŏn�܂�Ȃ��ǂ̂悤��<span class="en">URL</span>������ׂ��`�ŃT�[�u����܂��B���̂��߃X�^�C���V�[�g�A����<span class="en">HTML</span>�t�@�C���A�摜����<strong class="se">/whatever/ther/url</strong>�ƌ����`�ŃA�N�Z�X�ł��܂��B</p>
+<p>ブラウザで存在しない<strong class="se">/something</strong>ディレクトリにアクセスすると、<span class="en">Blosxom</span>は中に入ってきます。<br>
+これで、<strong class="se">/weblog</strong>で始まる<span class="en">URL</span>は<span class="en">rewite</span>エンジンにとらえられ、<strong class="se">blosxom.cgi</strong>に渡されます。<strong class="se">/weblog</strong>（そして追加の<strong class="se">/</strong>）の後は<span class="en">path_info</span>に従って<span class="en">CGI</span>に渡されます。<br>
+<strong class="se">/weblog</strong>で始まらないどのような<span class="en">URL</span>もあるべき形でサーブされます。そのためスタイルシート、他の<span class="en">HTML</span>ファイル、画像等は<strong class="se">/whatever/ther/url</strong>と言う形でアクセスできます。</p>
 </li>
 </ol>
 </li>
@@ -112,7 +112,7 @@ RewriteRule ^(.*)$ blosxom.cgi/$1 [L,QSA]
 <p><span class="en">Author: Rael Dornfest<br>
 Category: /faq/cgi<br>
 Date: 2003-07-26</span></p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_cgi_hide_url_bit.html
+++ b/faq_cgi_hide_url_bit.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - URLから/cgi-bin/blosxom.cgiをどうやったら隠せますか?</title>
 

--- a/faq_cgi_hide_url_bit.html
+++ b/faq_cgi_hide_url_bit.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_changed_rss.html
+++ b/faq_changed_rss.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - Blosxom��O�̃o�[�W��������A�b�v�O���[�h���܂����BRSS�ɉ��������Ă���̂ł����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - Blosxomを前のバージョンからアップグレードしました。RSSに何か生じているのですか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,66 +11,66 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">Blosxom</span>��O�̃o�[�W�����i<span class="en">0+4i</span>�������͂����ƑO�j����A�b�v�O���[�h���܂����B<span class="en">RSS</span>�ɉ��������Ă���̂ł����H</h2>
-<p>�J�e�S���Ƌ��L�ɑ΂���p�X�̏Љ�ɂ��Ȃ�ŁA�M����<span class="en">RSS</span>�����o��URL��<span class="en">blosxom.cgi/xml</span>����<span class="en">blosxom.cgi?flav=rss</span>�ɕύX����܂����B �������Ȃ��ƁA�f�B���N�g����<span class="en">/xml</span>�ƌ����p�X�������č쐬�ł��Ȃ��̂ł� --�����̔�Q�͖����Ƃ͎v���܂����A�F�߂���𓾂܂��� ;-)</p><p>���͍ŋ߂̎����҂��炱��<span class="en">RSS</span>�ɑ΂���<span class="en">URL</span>�͍L�����y���Ă���̂Ŗ�肪�񂶂�Ƃ̕񍐂��󂯂Ă��܂��B</p><p>�C���ł�p�ӂ��܂����B<span class="en">blosxom.cgi</span>�̈ȉ��̕����̃R�����g���O���ĉ������i<span class="en">#</span>�����j�F</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">Blosxom</span>を前のバージョン（<span class="en">0+4i</span>もしくはもっと前）からアップグレードしました。<span class="en">RSS</span>に何が生じているのですか？</h2>
+<p>カテゴリと共有に対するパスの紹介にちなんで、貴方の<span class="en">RSS</span>を取り出すURLは<span class="en">blosxom.cgi/xml</span>から<span class="en">blosxom.cgi?flav=rss</span>に変更されました。 そうしないと、ディレクトリに<span class="en">/xml</span>と言うパスを決して作成できないのです --多くの被害は無いとは思いますが、認めざるを得ません ;-)</p><p>私は最近の試験者からこの<span class="en">RSS</span>に対する<span class="en">URL</span>は広く普及しているので問題が報じるとの報告を受けています。</p><p>修正版を用意しました。<span class="en">blosxom.cgi</span>の以下の部分のコメントを外して下さい（<span class="en">#</span>を取る）：</p><pre class="en">
 #path_info() =~ m!/xml/?$! and $flavour = 'rss';
-</pre><p>���A���̂悤�ɂ��܂��F</p><pre class="en">
+</pre><p>を、次のようにします：</p><pre class="en">
 path_info() =~ m!/xml/?$! and $flavour = 'rss';
 </pre>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/upgrade<br>
 Date: 2003-07-26</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_changed_rss.html
+++ b/faq_changed_rss.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_changed_rss.html
+++ b/faq_changed_rss.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - Blosxomを前のバージョンからアップグレードしました。RSSに何か生じているのですか？</title>
 

--- a/faq_configure_permalinks.html
+++ b/faq_configure_permalinks.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - Blosxomのpermalinksの設定方法は？</title>
 

--- a/faq_configure_permalinks.html
+++ b/faq_configure_permalinks.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - Blosxom��permalinks�̐ݒ���@�́H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - Blosxomのpermalinksの設定方法は？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,60 +11,60 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">Blosxom</span>��<span class="en">permalinks</span>�̐ݒ���@��?</h2><p><span class="en">Blosxom</span>��2��ނ�<span class="en">permalinks</span>���T�|�[�g���Ă��܂��B���t����{�Ƃ������̂ƁA�t�@�C������{�Ƃ������̂ł��B</p><pre class="en">http://www.nelson.monkey.org/~nelson/weblog/2003/08/15#fn.html</pre><p>����͂�����̃��O�ւ̃����N�ƂȂ��Ă��܂��B������t���[�o�[�ō쐬����ɂ͈ȉ��̃p�^�[�����g���܂��B</p><pre class="en">$url/$yr/$mo_num/$da#$fn</pre><p>�t�@�C������{�Ƃ���<span class="en">permalinks</span>�͈ȉ��̂悤�Ȋ����ɂȂ�܂��B</p><pre class="en">http://www.nelson.monkey.org/~nelson/weblog/culture/kiteFlying.html</pre><p>����͓���̃��O�ւ̃����N�ɂȂ��Ă��܂��B���ɂ͉����\��������̂͂���܂���B������t���[�o�[�ō쐬����ɂ͈ȉ��̂悤�ȃp�^�[�����g���܂��B</p><pre class="en">$url$path/$fn.$flavour</pre><p>�t���[�o�[�t�@�C���������ꍇ�ɂ͓��t����{�Ƃ��������N���g���܂��B��X�̑�����<span class="en">Blosxom</span>�̍�҂��܂߂ăt�@�C������{�Ƃ���<span class="en">permalinks</span>���D��ł��܂��B<span class="en">Blosxom</span>���y�����̂͂ǂ����<span class="en">permalinks</span>�����삷��ƌ����Ƃ���ł��B�t���[�o�[�t�@�C����ҏW���邱�Ƃɂ���ĊȒP�ɂǂ���̃^�C�v��<span class="en">permalinks</span>��񋟂���̂������߂邱�Ƃ��ł��܂��B</p><div id="author">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">Blosxom</span>の<span class="en">permalinks</span>の設定方法は?</h2><p><span class="en">Blosxom</span>は2種類の<span class="en">permalinks</span>をサポートしています。日付を基本としたものと、ファイルを基本としたものです。</p><pre class="en">http://www.nelson.monkey.org/~nelson/weblog/2003/08/15#fn.html</pre><p>これはある日のログへのリンクとなっています。これをフレーバーで作成するには以下のパターンを使います。</p><pre class="en">$url/$yr/$mo_num/$da#$fn</pre><p>ファイルを基本とした<span class="en">permalinks</span>は以下のような感じになります。</p><pre class="en">http://www.nelson.monkey.org/~nelson/weblog/culture/kiteFlying.html</pre><p>これは特定のログへのリンクになっています。他には何も表示するものはありません。これをフレーバーで作成するには以下のようなパターンを使います。</p><pre class="en">$url$path/$fn.$flavour</pre><p>フレーバーファイルが無い場合には日付を基本としたリンクを使います。我々の多くは<span class="en">Blosxom</span>の作者を含めてファイルを基本とした<span class="en">permalinks</span>を好んでいます。<span class="en">Blosxom</span>が楽しいのはどちらの<span class="en">permalinks</span>も動作すると言うところです。フレーバーファイルを編集することによって簡単にどちらのタイプの<span class="en">permalinks</span>を提供するのかを決めることができます。</p><div id="author">
 <p class="en">Author: Nelson Minar<br>
 Category: /faq<br>
 Date: 2003-08-17</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_configure_permalinks.html
+++ b/faq_configure_permalinks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_datadir_correct_value.html
+++ b/faq_datadir_correct_value.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - ���̃T�C�g��$datadir�ɑ΂��鐳�m�Ȓl���ǂ�����Ċm�F����΂悢�̂ł����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - 私のサイトで$datadirに対する正確な値をどうやって確認すればよいのですか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,71 +11,71 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a namae="top" class="en"><span class="en">FAQ</span></a></h1><h2>���̃T�C�g��<span class="en">$datadir</span>�ɑ΂��鐳�m�Ȓl���ǂ�����Ċm�F����΂悢�̂ł����H</h2>
-<p><span class="en">$datadir</span>�ɑ΂��鐳�m�Ȓl���m�F����ł��ȒP�ȕ��@�́A�E�F�u�z�X�g��<span class="en">telnet</span>�܂���<span class="en">ssh</span>�Ń��O�C������&quot;<a href="faq_only_showing_the_default.html">�ǂ�����<span class="en">Blosxom</span>�͎��̃E�F�u���O�ł͂Ȃ��ĕW���̃w�b�_�ƃt�b�^��\������̂ł����H</a>&quot;�Ő������Ă�����@���g�����Ƃł��B</p><p>�v���o�C�_�̃T�[�o�[�Ƀ��O�C�����鎖���ł��Ȃ��ꍇ�ɂ͐��m�ȃf�B���N�g����m��̂͑����A����ɂȂ�܂��B</p><p>�v���o�C�_��PHP���g����ꍇ�A<span class="en">test.php</span>�ƌ����ȉ��̂悤�ȏ����ȃt�@�C�����g���Ă݂܂��F</p><pre class="en">
+<td id="contents"><h1><a namae="top" class="en"><span class="en">FAQ</span></a></h1><h2>私のサイトで<span class="en">$datadir</span>に対する正確な値をどうやって確認すればよいのですか？</h2>
+<p><span class="en">$datadir</span>に対する正確な値を確認する最も簡単な方法は、ウェブホストに<span class="en">telnet</span>または<span class="en">ssh</span>でログインして&quot;<a href="faq_only_showing_the_default.html">どうして<span class="en">Blosxom</span>は私のウェブログではなくて標準のヘッダとフッタを表示するのですか？</a>&quot;で説明している方法を使うことです。</p><p>プロバイダのサーバーにログインする事ができない場合には正確なディレクトリを知るのは多少、困難になります。</p><p>プロバイダでPHPが使える場合、<span class="en">test.php</span>と言う以下のような小さなファイルを使ってみます：</p><pre class="en">
 &lt;?
 phpinfo();
 ?&gt;
-</pre><p><span class="en">http://yourwebsite.com/test.php</span>�̂悤�ɂ��ČĂяo���ƁA�E�F�u�T�[�o�[�ɑ΂���<span class="en">DocumentRoot</span>���܂ޑ����̏�񂪓����A���ꂪ�M���ɓ�����^���Ă���܂��B</p><p><span class="en">PHP</span>�͎g�����Ƃ��ł��Ȃ����A<span class="en">CGI Perl</span>���W���[���͎g����ƌ����̂ł���Έȉ��̃X�N���v�g�Ńh�L�������g���[�g��\�������邱�Ƃ��ł��܂��B�ȉ��̃X�N���v�g��<span class="en">'dr.pl'</span>�Ƃ���<span class="en">CGI</span>�f�B���N�g���ɕۑ����A�u���E�U��<span class="en">http://yourwebsite.com/cgi-bin/dr.pl</span>�̂悤�ɂ��ăA�N�Z�X���ĉ������F </p><pre class="en">
+</pre><p><span class="en">http://yourwebsite.com/test.php</span>のようにして呼び出すと、ウェブサーバーに対する<span class="en">DocumentRoot</span>を含む多くの情報が得られ、これが貴方に答えを与えてくれます。</p><p><span class="en">PHP</span>は使うことができないが、<span class="en">CGI Perl</span>モジュールは使えると言うのであれば以下のスクリプトでドキュメントルートを表示させることができます。以下のスクリプトを<span class="en">'dr.pl'</span>として<span class="en">CGI</span>ディレクトリに保存し、ブラウザで<span class="en">http://yourwebsite.com/cgi-bin/dr.pl</span>のようにしてアクセスして下さい： </p><pre class="en">
 #!/usr/bin/perl
 use CGI qw/:standard :netscape/;
 print header();
 print &quot;&lt;BODY&gt;Document Root = $ENV{DOCUMENT_ROOT}&lt;/BODY&gt;\n&quot;;
-</pre><p>��x�T�[�o�[��<span class="en">DocumentRoot</span>��m���Ă��܂��Ό��<span class="en">/blosxom</span>�i�܂��͋M�����I������<span class="en">Blosxom</span>�̋L���ɑ΂���f�B���N�g���j���Ō�ɒǉ�����΂��ꂪ<span class="en">$datadir</span>�̐������l�ɂȂ�܂��B</p>
+</pre><p>一度サーバーの<span class="en">DocumentRoot</span>を知ってしまえば後は<span class="en">/blosxom</span>（または貴方が選択した<span class="en">Blosxom</span>の記事に対するディレクトリ）を最後に追加すればそれが<span class="en">$datadir</span>の正しい値になります。</p>
 <div id="author">
 <p class="en">Author: Tony Williams<br>
 Category: /faq/install<br>
 Date: 2003-07-27</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_datadir_correct_value.html
+++ b/faq_datadir_correct_value.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_datadir_correct_value.html
+++ b/faq_datadir_correct_value.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - 私のサイトで$datadirに対する正確な値をどうやって確認すればよいのですか？</title>
 

--- a/faq_directories_numeric.html
+++ b/faq_directories_numeric.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - ディレクトリ名を数字で始めることはできますか？</title>
 

--- a/faq_directories_numeric.html
+++ b/faq_directories_numeric.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,“ú–{Œê,–|–ó">
-<title>blosxomƒTƒCƒg‚Ì“ú–{Œê–ó::FAQ - ƒfƒBƒŒƒNƒgƒŠ–¼‚ð”Žš‚ÅŽn‚ß‚é‚±‚Æ‚Í‚Å‚«‚Ü‚·‚©H</title>
+<meta name="keywords" content="blosxom,æ—¥æœ¬èªž,ç¿»è¨³">
+<title>blosxomã‚µã‚¤ãƒˆã®æ—¥æœ¬èªžè¨³::FAQ - ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã‚’æ•°å­—ã§å§‹ã‚ã‚‹ã“ã¨ã¯ã§ãã¾ã™ã‹ï¼Ÿ</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,62 +11,62 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::“ú–{Œê–ó</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="ƒtƒŒ[ƒ€">
+<div id="header"><span class="en">blosxom</span>::æ—¥æœ¬èªžè¨³</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="ãƒ•ãƒ¬ãƒ¼ãƒ ">
 <tbody>
 <tr>
 <td id="menu">
-<h4>–|–ó‚É‚Â‚¢‚Ä</h4>
+<h4>ç¿»è¨³ã«ã¤ã„ã¦</h4>
 <ul class="mid">
-<li><a href="index.html" title="‚¨“Ç‚Ý‚­‚¾‚³‚¢">‚¨“Ç‚Ý‚­‚¾‚³‚¢</a></li>
+<li><a href="index.html" title="ãŠèª­ã¿ãã ã•ã„">ãŠèª­ã¿ãã ã•ã„</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom‚É‚Â‚¢‚Ä"><span class="en">Blosxom</span>‚É‚Â‚¢‚Ä</a></li>
-<li><a href="features.html" title="Blosxom‚Ì‹@”\">‹@”\</a></li>
-<li><a href="colophon.html" title="‰œ•t">‰œ•t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ƒjƒ…[ƒX">ƒjƒ…[ƒXi‰pŒêj</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="ƒ[ƒŠƒ“ƒOƒŠƒXƒg">ƒ[ƒŠƒ“ƒOƒŠƒXƒgi‰pŒêj</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="Šñ‘¡">Šñ‘¡i‰pŒêj</a></li>
+<li><a href="about.html" title="Blosxomã«ã¤ã„ã¦"><span class="en">Blosxom</span>ã«ã¤ã„ã¦</a></li>
+<li><a href="features.html" title="Blosxomã®æ©Ÿèƒ½">æ©Ÿèƒ½</a></li>
+<li><a href="colophon.html" title="å¥¥ä»˜">å¥¥ä»˜</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ãƒ‹ãƒ¥ãƒ¼ã‚¹">ãƒ‹ãƒ¥ãƒ¼ã‚¹ï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆ">ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="å¯„è´ˆ">å¯„è´ˆï¼ˆè‹±èªžï¼‰</a></li>
 </ul>
-<h4>ƒ†[ƒUŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>ãƒ¦ãƒ¼ã‚¶å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom‚ÌŠT—v">ŠT—v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom‚ÌƒCƒ“ƒXƒg[ƒ‹">ƒCƒ“ƒXƒg[ƒ‹</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom‚ÌÝ’è">ŠÂ‹«Ý’è</a></li>
-<li><a href="doc_users_blog.html" title="ƒEƒFƒuƒƒO">ƒEƒFƒuƒƒO</a></li>
-<li><a href="doc_users_view.html" title="ƒEƒFƒuƒƒO‚Ì‰{——">‰{——</a></li>
-<li><a href="doc_users_flavour.html" title="ƒtƒŒ[ƒo[">ƒtƒŒ[ƒo[</a></li>
-<li><a href="doc_users_syndicate.html" title="ƒVƒ“ƒWƒP[ƒg">ƒVƒ“ƒWƒP[ƒg</a></li>
-<li><a href="doc_users_plugins.html" title="ƒvƒ‰ƒOƒCƒ“">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="plugin_registry.html" title="ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW">ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW</a></li>
-<li><a href="doc_users_configure_static.html" title="Ã“I•\Ž¦‚ÌÝ’è">Ã“I•\Ž¦‚ÌÝ’è</a></li>
-<li><a href="faq.html" title="—Ç‚­‚ ‚éŽ¿–â"><span class="en">faq</span></a></li>
-<li>Žg—p—á*</li>
+<li><a href="doc_users_overview.html" title="Blosxomã®æ¦‚è¦">æ¦‚è¦</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomã®ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«">ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomã®è¨­å®š">ç’°å¢ƒè¨­å®š</a></li>
+<li><a href="doc_users_blog.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°">ã‚¦ã‚§ãƒ–ãƒ­ã‚°</a></li>
+<li><a href="doc_users_view.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°ã®é–²è¦§">é–²è¦§</a></li>
+<li><a href="doc_users_flavour.html" title="ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼">ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼</a></li>
+<li><a href="doc_users_syndicate.html" title="ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ">ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ</a></li>
+<li><a href="doc_users_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="plugin_registry.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸</a></li>
+<li><a href="doc_users_configure_static.html" title="é™çš„è¡¨ç¤ºã®è¨­å®š">é™çš„è¡¨ç¤ºã®è¨­å®š</a></li>
+<li><a href="faq.html" title="è‰¯ãã‚ã‚‹è³ªå•"><span class="en">faq</span></a></li>
+<li>ä½¿ç”¨ä¾‹*</li>
 </ul>
-<h4>ŠJ”­ŽÒŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>é–‹ç™ºè€…å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="ŠT—vFŠJ”­ŽÒŒü‚¯">ŠT—v</a></li>
-<li><a href="doc_dev_plugins.html" title="ƒvƒ‰ƒOƒCƒ“FŠJ”­ŽÒŒü‚¯">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="doc_dev_plugin_register.html" title="ŠJ”­ŽÒŒü‚¯Fƒvƒ‰ƒOƒCƒ““o˜^">ƒvƒ‰ƒOƒCƒ“‚Ì“o˜^</a></li>
+<li><a href="doc_dev_overview.html" title="æ¦‚è¦ï¼šé–‹ç™ºè€…å‘ã‘">æ¦‚è¦</a></li>
+<li><a href="doc_dev_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ï¼šé–‹ç™ºè€…å‘ã‘">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="doc_dev_plugin_register.html" title="é–‹ç™ºè€…å‘ã‘ï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç™»éŒ²</a></li>
 </ul>
-<h4>ƒ_ƒEƒ“ƒ[ƒh</h4>
+<h4>ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="‘S‚Ä‚Ìl‚Ö">‘S‚Ä‚Ìl‚Ö</a></li>
-<li><a href="license.html" title="ƒ‰ƒCƒZƒ“ƒX">ƒ‰ƒCƒZƒ“ƒX</a></li>
-<li>‹¤“¯§ì*</li>
+<li><a href="downloads.html" title="å…¨ã¦ã®äººã¸">å…¨ã¦ã®äººã¸</a></li>
+<li><a href="license.html" title="ãƒ©ã‚¤ã‚»ãƒ³ã‚¹">ãƒ©ã‚¤ã‚»ãƒ³ã‚¹</a></li>
+<li>å…±åŒåˆ¶ä½œ*</li>
 </ul>
-<p>*ŒöŽ®ƒTƒCƒg‚Å–¢Ž·•M</p>
+<p>*å…¬å¼ã‚µã‚¤ãƒˆã§æœªåŸ·ç­†</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>ƒfƒBƒŒƒNƒgƒŠ–¼‚ð”Žš‚ÅŽn‚ß‚é‚±‚Æ‚Í‚Å‚«‚Ü‚·‚©?</h2><p>‚Å‚«‚Ü‚¹‚ñB<span class="en">Blosxom</span>‚Å‚Í”Žš‚ÅŽn‚Ü‚éƒfƒBƒŒƒNƒgƒŠ–¼‚ÍŽg‚¦‚Ü‚¹‚ñBÅ‰‚Ì•¶Žš‚Æ‚µ‚ÄŽg‚í‚È‚¯‚ê‚Î”Žš‚ðƒfƒBƒŒƒNƒgƒŠ–¼Aƒtƒ@ƒCƒ‹–¼‚ÉŽg‚¤‚±‚Æ‚Í‚Å‚«‚Ü‚·B‚±‚ê‚Í<span class="en">Blosxom</span>‚ªƒpƒXi—á 
-<span class="en">/some/path</span>j‚Æ“ú•ti—á <span class="en">/2003/09</span>j‚ð‰ðŽß‚µA‚»‚ê‚ç‚ðD‚èŒð‚º‚ÄŽg—p‚·‚é‚©‚ç‚Å‚·i—á <span class="en">/some/path/2003/09</span>‚Å<span class="en">/some/path</span>‚Ì2003”N9ŒŽ‚Ì‚Ý‚ÌƒƒO‚ð•\Ž¦‚µ‚Ü‚·jB</p>
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã‚’æ•°å­—ã§å§‹ã‚ã‚‹ã“ã¨ã¯ã§ãã¾ã™ã‹?</h2><p>ã§ãã¾ã›ã‚“ã€‚<span class="en">Blosxom</span>ã§ã¯æ•°å­—ã§å§‹ã¾ã‚‹ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã¯ä½¿ãˆã¾ã›ã‚“ã€‚æœ€åˆã®æ–‡å­—ã¨ã—ã¦ä½¿ã‚ãªã‘ã‚Œã°æ•°å­—ã‚’ãƒ‡ã‚£ãƒ¬ã‚¯ãƒˆãƒªåã€ãƒ•ã‚¡ã‚¤ãƒ«åã«ä½¿ã†ã“ã¨ã¯ã§ãã¾ã™ã€‚ã“ã‚Œã¯<span class="en">Blosxom</span>ãŒãƒ‘ã‚¹ï¼ˆä¾‹ 
+<span class="en">/some/path</span>ï¼‰ã¨æ—¥ä»˜ï¼ˆä¾‹ <span class="en">/2003/09</span>ï¼‰ã‚’è§£é‡ˆã—ã€ãã‚Œã‚‰ã‚’ç¹”ã‚Šäº¤ãœã¦ä½¿ç”¨ã™ã‚‹ã‹ã‚‰ã§ã™ï¼ˆä¾‹ <span class="en">/some/path/2003/09</span>ã§<span class="en">/some/path</span>ã®2003å¹´9æœˆã®ã¿ã®ãƒ­ã‚°ã‚’è¡¨ç¤ºã—ã¾ã™ï¼‰ã€‚</p>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/directories<br>
 Date: 2003-09-07</p>
-</div><p class="nextLink"><a href="#top">[ƒy[ƒW‚Ìæ“ª‚Ö–ß‚é]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ãƒšãƒ¼ã‚¸ã®å…ˆé ­ã¸æˆ»ã‚‹]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_directories_numeric.html
+++ b/faq_directories_numeric.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_iis_path_info_issue.html
+++ b/faq_iis_path_info_issue.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - IIS��PATH_INFO�̖��ɂ��ւ�炸Blsoxom�𓮍삳����ɂ͂ǂ�����Ηǂ��̂ł����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - IISのPATH_INFOの問題にも関わらずBlsoxomを動作させるにはどうすれば良いのですか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,70 +11,70 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">IIS</span>��<span class="en">PATH_INFO</span>�̖��ɂ��ւ�炸<span class="en">Blosxom</span>�𓮍삳����ɂ͂ǂ�����Ηǂ��̂ł����H</h2>
-<p><span class="en">IIS</span>��<span class="en">PATH_INFO</span>�𗝉����A������<span class="en">Blosxom</span>�i������<span class="en">PATH_INFO</span>���g�����̃X�N���v�g�j�����m�ɓ��삷��悤�ɂ�����@�͊������܂��B</p><p><span class="en">PerlMonks</span>��<span class="en">IIS</span>��<span class="en">&quot;ScriptMaps&quot; property (http://msdn.microsoft.com/library/default.asp?url=/library/en-us/iisref/html/psdk/asp/apro9tkj.asp)</span>���g����<span class="en">&quot;Fix ActiveState Script Maps (IIS)&quot; (http://perlmonks.thepen.com/102907.html)</span>��񋟂��Ă��܂��B</p><p><span class="en">Blosxom</span>���[�U�ł���<span class="en">Allie Rogers (http://radio.weblogs.com/0106608/)</span>��<span class="en">IIS</span>�̐ݒ�Ɋւ��Ĉȉ��̕��@���Ă��Ă��܂��B���̐ݒ�̌��ʂ͏�L��<span class="en">PerlMonks</span>�̃X�N���v�g�Ǝ��Ă��܂��B�������Ȃ���A<span class="en">PerlMonks</span>�̃X�N���v�g��<span class="en">Blosxom CGI</span>�X�N���v�g���܂ރt�H���_�ɑ΂���&quot;<span class="en">execute</span>�i���s�j&quot;����^����ƌ����_�ŗD�ꂽ������ł��B���s���𖳌��ɂ��邱�ƂŎ኱���S�ȃE�F�u�T�[�o��񋟂��鎖�ɂȂ�A<span class="en">&quot;Code Red&quot;</span>�̂悤�ȋ��Ђ����邱�ƂɂȂ�܂��B</p><p><span class="en">IIS</span>�̐ݒ������̂ɂǂ���̕��@���M�����g�����ɂ͊֌W�Ȃ��A<span class="en">ActiveState Perl</span>��<span class="en">ISAP</span>�����^�C���i<span class="en">PerllS.dll</span>�j��<span class="en">PATH_INFO</span>�𐳊m�Ɉ��������ł��Ȃ��̂ŁA��ɕW����<span class="en">Perl</span>�C���^�v���^�i<span class="en">Perl.exe</span>�j���g��Ȃ��Ă͂Ȃ�܂���B</p>
-<h3><span class="en">Allie</span>�̎菇�F</h3><p><span class="en">ActiveState</span>�̕W����<span class="en">Perl</span>�A������<span class="en">Windows2000</span>��<span class="en">IIS 5</span>���g���Ă���Ɖ��肷��ƁA<span class="en">&quot;Application Configuration&quot;</span>�v���p�e�B�_�C�A���O��<span class="en">&quot;App Mappings&quot;</span>��<span class="en">&quot;Application Mappings&quot;</span>���C������K�v������܂��B���̃_�C�A���O�ɃA�N�Z�X����ɂ�<span class="en">IIS</span>�̊Ǘ��R���\�[�����J���i<span class="en">Windows2000 Pro</span>�ƃT�[�o�̃o�[�W�����ɂ���ĕς��܂��̂�<span class="en">IIS</span>�̃h�L�������g���Q�Ƃ��ĉ������j�B</p><p>�Ǘ��R���\�[�����獶�̃c���[�������čs���A<span class="en">&quot;blosxom.cgi&quot;</span>�X�N���v�g�����鉼�z�f�B���N�g���������܂��B���̉��z�f�B���N�g�����E�N���b�N���A<span class="en">&quot;Properties&quot;</span>��I�����܂��B<span class="en">&quot;Configuration..&quot;</span>�{�^�����N���b�N�����<span class="en">&quot;Application Configuration&quot;</span>�v���p�e�B�_�C�A���O���J���܂��B<span class="en">&quot;App Mappings&quot;</span>�^�u��̃��X�g�͑S�Ă�<span class="en">&quot;Application Mappings&quot;</span>��\�����Ă��܂��B�W���ł́A<span class="en">ActiveState</span>��<span class="en">&quot;.pl&quot;</span>�g���q�ɑ΂���}�b�s���O���C���X�g�[�����܂��B������C������<span class="en">&quot;.cgi&quot;</span>�g���q��ǉ����܂��B�����Œ��ӂ������̂́A<span class="en">&quot;Check that file exists&quot;</span>�Ƀ`�F�b�N��������<strong>���Ȃ�</strong>���Ƃ��m�F���鎖�ł��B��L��<span class="en">&quot;.cgi&quot;</span>�t�@�C���̐ݒ�͈ȉ��̂悤�Ȋ����ɂȂ�܂��F</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2><span class="en">IIS</span>の<span class="en">PATH_INFO</span>の問題にも関わらず<span class="en">Blosxom</span>を動作させるにはどうすれば良いのですか？</h2>
+<p><span class="en">IIS</span>が<span class="en">PATH_INFO</span>を理解し、そして<span class="en">Blosxom</span>（そして<span class="en">PATH_INFO</span>を使う他のスクリプト）が正確に動作するようにする方法は幾つかあります。</p><p><span class="en">PerlMonks</span>は<span class="en">IIS</span>の<span class="en">&quot;ScriptMaps&quot; property (http://msdn.microsoft.com/library/default.asp?url=/library/en-us/iisref/html/psdk/asp/apro9tkj.asp)</span>を使った<span class="en">&quot;Fix ActiveState Script Maps (IIS)&quot; (http://perlmonks.thepen.com/102907.html)</span>を提供しています。</p><p><span class="en">Blosxom</span>ユーザである<span class="en">Allie Rogers (http://radio.weblogs.com/0106608/)</span>は<span class="en">IIS</span>の設定に関して以下の方法を提案しています。この設定の結果は上記の<span class="en">PerlMonks</span>のスクリプトと似ています。しかしながら、<span class="en">PerlMonks</span>のスクリプトは<span class="en">Blosxom CGI</span>スクリプトを含むフォルダに対して&quot;<span class="en">execute</span>（実行）&quot;許可を与えると言う点で優れた解決策です。実行許可を無効にすることで若干安全なウェブサーバを提供する事になり、<span class="en">&quot;Code Red&quot;</span>のような脅威から守ることになります。</p><p><span class="en">IIS</span>の設定をするのにどちらの方法を貴方が使うかには関係なく、<span class="en">ActiveState Perl</span>の<span class="en">ISAP</span>ランタイム（<span class="en">PerllS.dll</span>）は<span class="en">PATH_INFO</span>を正確に扱う事がでいないので、常に標準の<span class="en">Perl</span>インタプリタ（<span class="en">Perl.exe</span>）を使わなくてはなりません。</p>
+<h3><span class="en">Allie</span>の手順：</h3><p><span class="en">ActiveState</span>の標準の<span class="en">Perl</span>、そして<span class="en">Windows2000</span>で<span class="en">IIS 5</span>を使っていると仮定すると、<span class="en">&quot;Application Configuration&quot;</span>プロパティダイアログの<span class="en">&quot;App Mappings&quot;</span>の<span class="en">&quot;Application Mappings&quot;</span>を修正する必要があります。このダイアログにアクセスするには<span class="en">IIS</span>の管理コンソールを開き（<span class="en">Windows2000 Pro</span>とサーバのバージョンによって変わりますので<span class="en">IIS</span>のドキュメントを参照して下さい）。</p><p>管理コンソールから左のツリーを下って行き、<span class="en">&quot;blosxom.cgi&quot;</span>スクリプトがある仮想ディレクトリを見つけます。この仮想ディレクトリを右クリックし、<span class="en">&quot;Properties&quot;</span>を選択します。<span class="en">&quot;Configuration..&quot;</span>ボタンをクリックすると<span class="en">&quot;Application Configuration&quot;</span>プロパティダイアログが開きます。<span class="en">&quot;App Mappings&quot;</span>タブ上のリストは全ての<span class="en">&quot;Application Mappings&quot;</span>を表示しています。標準では、<span class="en">ActiveState</span>は<span class="en">&quot;.pl&quot;</span>拡張子に対するマッピングをインストールします。これを修正して<span class="en">&quot;.cgi&quot;</span>拡張子を追加します。ここで注意したいのは、<span class="en">&quot;Check that file exists&quot;</span>にチェックが入って<strong>いない</strong>ことを確認する事です。上記の<span class="en">&quot;.cgi&quot;</span>ファイルの設定は以下のような感じになります：</p><pre class="en">
 Executable: C:\perl\bin\Perl.exe &quot;%s&quot; %s
 Extension: .cgi
 Verbs (Limit to): GET, HEAD, POST
 Script engine: NOT CHECKED
 Check that file exists: NOT CHECKED
 </pre>
-<p>�����<span class="en">Windows XP</span>��<span class="en">IIS 6</span>�Ɠ��l��<span class="en">NT4</span>��<span class="en">IIS 4</span>�ł����܂��s���܂��B</p><p>��葽���̏���<span class="en">http://www.jmarshall.com/tools/cgiproxy/faq.html#q6</span>�Ɠ��l��<span class="en">Microsoft</span>�̃i���b�W�x�[�X<span class="en">Q184320</span>�� <span class="en">Q252352</span>�Ō�����܂��B</p>
+<p>これは<span class="en">Windows XP</span>の<span class="en">IIS 6</span>と同様に<span class="en">NT4</span>の<span class="en">IIS 4</span>でもうまく行きます。</p><p>より多くの情報は<span class="en">http://www.jmarshall.com/tools/cgiproxy/faq.html#q6</span>と同様に<span class="en">Microsoft</span>のナレッジベース<span class="en">Q184320</span>と <span class="en">Q252352</span>で見つかります。</p>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/operating_system/windows/iis<br>
 Date: 2003-07-26</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_iis_path_info_issue.html
+++ b/faq_iis_path_info_issue.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_iis_path_info_issue.html
+++ b/faq_iis_path_info_issue.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - IISのPATH_INFOの問題にも関わらずBlsoxomを動作させるにはどうすれば良いのですか？</title>
 

--- a/faq_include_function_individual.html
+++ b/faq_include_function_individual.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - �e���O�ipermalinks�j�y�[�W�݂̂ɑ����̋@�\�ǉ���������@�́H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - 各ログ（permalinks）ページのみに多少の機能追加を入れる方法は？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,63 +11,63 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>�e���O�i<span class="en">permalinks</span>�j�y�[�W�݂̂ɑ����̋@�\�ǉ���������@��?</h2><p>���͂� <span class="en">interpolate_fancy</span> �v���O�C�����g���Έȉ��̂悤�Ȃ��Ƃ��ł��܂��B</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>各ログ（<span class="en">permalinks</span>）ページのみに多少の機能追加を入れる方法は?</h2><p>強力な <span class="en">interpolate_fancy</span> プラグインを使えば以下のようなことができます。</p><pre class="en">
 &lt;?$path_info unlike=&quot;(^[^\.]+/?$)|(^$)|(index\.\w+$)&quot;&gt;writeback stuff goes here&lt;/?&gt;
-</pre><p>����� �u<span class="en">URL/path_info</span>���f�B���N�g���i�� <span class="en">some/path/</span>�j�ł͖����A�܂������̃u�����N�i�� <span class="en">/</span>�j�ł͂Ȃ��A�����ăC���f�b�N�X�y�[�W�ł͂Ȃ��i�� 
-<span class="en">/some/path/index.html</span>�j�ꍇ�͌X�̃G���g���[�y�[�W�ł�����A���̏ꍇ�̓��C�g�o�b�N��ǂݍ��ށv�ƌ������Ƃ��Ӗ����Ă��܂��B</p><div id="author">
+</pre><p>これは 「<span class="en">URL/path_info</span>がディレクトリ（例 <span class="en">some/path/</span>）では無い、まったくのブランク（例 <span class="en">/</span>）ではない、そしてインデックスページではない（例 
+<span class="en">/some/path/index.html</span>）場合は個々のエントリーページであから、この場合はライトバックを読み込む」と言うことを意味しています。</p><div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/display<br>
 Date: 2003-09-07</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_include_function_individual.html
+++ b/faq_include_function_individual.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - 各ログ（permalinks）ページのみに多少の機能追加を入れる方法は？</title>
 

--- a/faq_include_function_individual.html
+++ b/faq_include_function_individual.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_manipulate_order_plugin.html
+++ b/faq_manipulate_order_plugin.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - プログラム的にプラグインの実行順序を操作することはできますか？</title>
 

--- a/faq_manipulate_order_plugin.html
+++ b/faq_manipulate_order_plugin.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - �v���O�����I�Ƀv���O�C���̎��s�����𑀍삷�邱�Ƃ͂ł��܂����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - プログラム的にプラグインの実行順序を操作することはできますか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,63 +11,63 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>�v���O�����I�Ƀv���O�C���̎��s�����𑀍삷�邱�Ƃ͂ł��܂���?</h2><p>�ł��܂��B<span class="en">config</span>�v���O�C�����g���A<span class="en">Blosxom</span>�̃f�[�^�f�B���N�g���̃��[�g��<span class="en">config</span>�t�@�C����u���Ă��̃t�@�C���Ɉȉ��̂悤�Ȋ����̋L�q�����܂��B</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>プログラム的にプラグインの実行順序を操作することはできますか?</h2><p>できます。<span class="en">config</span>プラグインを使い、<span class="en">Blosxom</span>のデータディレクトリのルートに<span class="en">config</span>ファイルを置いてそのファイルに以下のような感じの記述をします。</p><pre class="en">
 @blosxom::plugins = ('ay', 'bee', 'sea', 'dee', 'eeee', ... 'lastplugin');
-</pre><p>���ۂɁA�قȂ�<span class="en">config</span>�t�@�C�����قȂ�f�B���N�g���ɒu���΁A�f�B���N�g���̃v���O�C���̏�����ύX���邱�Ƃ��ł��܂��B���ۂ̎��ۂɁA�t���[�o�[�ł��ł��܂��B�قȂ�f�B���N�g����<span class="en">config.flavourname</span>��u���܂��B</p>
+</pre><p>実際に、異なる<span class="en">config</span>ファイルを異なるディレクトリに置けば、ディレクトリのプラグインの順序を変更することができます。実際の実際に、フレーバーでもできます。異なるディレクトリに<span class="en">config.flavourname</span>を置きます。</p>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/plugins<br>
 Date: 2003-09-07</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_manipulate_order_plugin.html
+++ b/faq_manipulate_order_plugin.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_meta_data.html
+++ b/faq_meta_data.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - �ǂ�����ă��O�t�@�C���̓��t�⑼�̃��^�f�[�^�����o���̂ł����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - どうやってログファイルの日付や他のメタデータを取り出すのですか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,56 +11,56 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>�ǂ�����ă��O�t�@�C���̓��t�⑼�̃��^�f�[�^�����o���̂ł���? </h2><p>�����<span class="en">Blosxom</span>��<span class="en">meta</span>�f�[�^���ŏ��Ɏg������A<span class="en">entriescache</span>�v���O�C���Ɠ��t���������X�^���v�t�@�C�����g�����肷��ꍇ�Ɉ�ʓI�Ȗ��ƂȂ��Ă��܂��B</p><p>���́A<span class="en">meta</span>�f�[�^�̍s�ƃG�C���A�X���ǂ��ɒu�����Ƃ������ƂɊւ��鍬���ɂ���܂��B<span class="en">Blosxom</span>�̓��O�̃e�L�X�g�t�@�C����2�̂��Ƃ����肷�邽�߂Ɏg���Ă��܂��B�����̓^�C�g���Ɩ{���ŁA�^�C�g���̓t�@�C����1�s�ځA�����Ďc��͖{���ɂȂ�܂��B<span class="en">meta</span>�f�[�^�͖{���̈ꕔ�łȂ��Ă͂Ȃ炸�A���̂��߂�2�s�ځA�܂�1�s�ڂ̃^�C�g���̎��ɗ���K�v������܂��B</p><p>�ȉ��̓T���v���t�@�C���ł��F</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>どうやってログファイルの日付や他のメタデータを取り出すのですか? </h2><p>これは<span class="en">Blosxom</span>で<span class="en">meta</span>データを最初に使ったり、<span class="en">entriescache</span>プラグインと日付を持ったスタンプファイルを使ったりする場合に一般的な問題となっています。</p><p>問題は、<span class="en">meta</span>データの行とエイリアスをどこに置くかということに関する混乱にあります。<span class="en">Blosxom</span>はログのテキストファイルを2つのことを決定するために使っています。それらはタイトルと本文で、タイトルはファイルの1行目、そして残りは本文になります。<span class="en">meta</span>データは本文の一部でなくてはならず、そのために2行目、つまり1行目のタイトルの次に来る必要があります。</p><p>以下はサンプルファイルです：</p><pre class="en">
 I Am The Title
 meta-date: 23/04/2003
 This is the body of my post.
@@ -69,7 +69,7 @@ This is the body of my post.
 <p class="en">Author: Tony Williams<br>
 Category: /faq/plugins<br>
 Date: 2003-09-15</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_meta_data.html
+++ b/faq_meta_data.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_meta_data.html
+++ b/faq_meta_data.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - どうやってログファイルの日付や他のメタデータを取り出すのですか？</title>
 

--- a/faq_only_showing_the_default.html
+++ b/faq_only_showing_the_default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - どうしてBlosxomは私のウェブログではなくて標準のヘッダとフッタを表示するのですか？</title>
 

--- a/faq_only_showing_the_default.html
+++ b/faq_only_showing_the_default.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_only_showing_the_default.html
+++ b/faq_only_showing_the_default.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - �ǂ�����Blosxom�͎��̃E�F�u���O�ł͂Ȃ��ĕW���̃w�b�_�ƃt�b�^��\������̂ł����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - どうしてBlosxomは私のウェブログではなくて標準のヘッダとフッタを表示するのですか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,70 +11,70 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>�ǂ�����<span class="en">Blosxom</span>�͎��̃E�F�u���O�ł͂Ȃ��ĕW���̃w�b�_�ƃt�b�^��\������̂ł����H</h2>
-<p>�����Ƃ��\���Ƃ��čl�����鎖�́A�M����<span class="en">blosxom.cgi</span>��<span class="en">$datadir</span>�ŊԈ�����f�B���N�g���i<span class="en">Mac</span>���[�U�ł̓t�H���_�ƌ����܂��j��ݒ肵�Ă���ƌ������Ƃł��B�����<span class="en">Blosxom</span>��<span class="en">ISP</span>�܂��̓E�F�u�z�X�e�B���O��Ђ̃}�V���ɒu���Ă���ꍇ�ɗǂ������܂��B�M���̃z�[���f�B���N�g���𕷂����Ƃ��ɋM�����Ԉ�������𕷂������A�ނ炪�Ԉ���������������������������܂��B</p><p><span class="en">FTP</span>�Ń��O�C���A�܂��̓R�}���h���C���ňȉ��̏ꏊ�ł��鎖������������A</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>どうして<span class="en">Blosxom</span>は私のウェブログではなくて標準のヘッダとフッタを表示するのですか？</h2>
+<p>もっとも可能性として考えられる事は、貴方が<span class="en">blosxom.cgi</span>の<span class="en">$datadir</span>で間違ったディレクトリ（<span class="en">Mac</span>ユーザではフォルダと言います）を設定していると言うことです。これは<span class="en">Blosxom</span>を<span class="en">ISP</span>またはウェブホスティング会社のマシンに置いている場合に良くおきます。貴方のホームディレクトリを聞いたときに貴方が間違った事を聞いたか、彼らが間違った事を言ったか等があげられます。</p><p><span class="en">FTP</span>でログイン、またはコマンドラインで以下の場所である事が分かったら、</p><pre class="en">
 /home/username
 </pre>
-<p>�܂��͎����悤�ȏꍇ�A�M��������ꏊ�ւ̊��S�ȃp�X�ł͂Ȃ���������܂���B���̂��߁A<span class="en">blosxom</span>�f�B���N�g�����쐬����<span class="en">$datadir</span>��<span class="en">/home/username/blosxom</span>�Ɛݒ肵�āA<span class="en">Blosxom</span>���W����<span class="en">&quot;Blosxom&quot;</span>�w�b�_��<span class="en">&quot;Powerd by Blosxom&quot;</span>�t�b�^���܂ރy�[�W��\������ꍇ�ɂ�<span class="en">Blosxom</span>�͋M���̃E�F�u���O�������邱�Ƃ��ł��Ă��܂���B</p><p>�M�������ۂɂǂ��ɂ���̂��m�F����ɂ́A<span class="en">telnet</span>��<span class="en">ssh</span>�A�܂���<span class="en">FTP</span>�Ń��O�C�����ăR�}���h���C���ňȉ��̂悤�ɓ��͂��Ă݂܂��F</p><pre class="en">
+<p>または似たような場合、貴方がいる場所への完全なパスではないかもしれません。そのため、<span class="en">blosxom</span>ディレクトリを作成して<span class="en">$datadir</span>に<span class="en">/home/username/blosxom</span>と設定して、<span class="en">Blosxom</span>が標準の<span class="en">&quot;Blosxom&quot;</span>ヘッダと<span class="en">&quot;Powerd by Blosxom&quot;</span>フッタを含むページを表示する場合には<span class="en">Blosxom</span>は貴方のウェブログを見つけることができていません。</p><p>貴方が実際にどこにいるのか確認するには、<span class="en">telnet</span>や<span class="en">ssh</span>、または<span class="en">FTP</span>でログインしてコマンドラインで以下のように入力してみます：</p><pre class="en">
 cd&lt;return&gt;
 pwd&lt;return&gt;
-</pre><p>�i<span class="en">&lt;return&gt;</span>�̓L�[�{�[�h�̃��^�[���L�[�������ƌ����Ӗ��ł��j</p><p>���̃R�}���h�ŋM���̌��݂̏ꏊ���\�������̂ŁA<span class="en">$datadir</span>�ɐݒ肷�ׂ��l��m�邱�Ƃ��ł��܂��B���̃T�[�o�̈�ł͎���<span class="en">/home/rael</span>�ŁA���́i<span class="en">Mac OS X</span>�j�T�[�o�[�ł͎���<span class="en">/Users/rael</span>�ɂȂ�܂��B�ȑO��<span class="en">ISP</span>�ł�<span class="en">/home/users/r/rael</span>���\������<span class="en">/home/rael</span>�ɂȂ��Ă��܂����B</p><p>���̂��߁A����<span class="en">pwd</span>�R�}���h��<span class="en">/home/users/username</span>�ƕ\�����A�M�����z�[���f�B���N�g���Ƀf�B���N�g��/�t�H���_���쐬�����̂ł���΁A<span class="en">$datadir</span>�͈ȉ��̂悤�Ȋ����ɂ��܂��F</p><pre class="en">
+</pre><p>（<span class="en">&lt;return&gt;</span>はキーボードのリターンキーを押すと言う意味です）</p><p>このコマンドで貴方の現在の場所が表示されるので、<span class="en">$datadir</span>に設定すべき値を知ることができます。私のサーバの一つでは私は<span class="en">/home/rael</span>で、他の（<span class="en">Mac OS X</span>）サーバーでは私は<span class="en">/Users/rael</span>になります。以前の<span class="en">ISP</span>では<span class="en">/home/users/r/rael</span>が表向きは<span class="en">/home/rael</span>になっていました。</p><p>そのため、もし<span class="en">pwd</span>コマンドが<span class="en">/home/users/username</span>と表示し、貴方がホームディレクトリにディレクトリ/フォルダを作成したのであれば、<span class="en">$datadir</span>は以下のような感じにします：</p><pre class="en">
 my $datadir = &quot;/home/users/username/blosxom&quot;;
 </pre>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/general<br>
 Date: 2003-07-26</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_particular_order_plugin.html
+++ b/faq_particular_order_plugin.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - ����̏��ԂŃv���O�C�������s������ɂ́H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - 特定の順番でプラグインを実行させるには？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,61 +11,61 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>����̏��ԂŃv���O�C�������s������ɂ�?</h2><p>�v���O�C���͕W���ŃA���t�@�x�b�g���Ŏ��s����܂��i<span class="en">file</span>��<span class="en">writeback</span>�̑O�Ɏ��s����܂��j�B�v���O�C���̎��s������ύX���邽�߂̂����Ƃ��ȒP�ȕ��@�́A�ԍ���t���邱�Ƃł��B<span class="en">writeback</span>�v���O�C���̖��O��ύX���A�Ⴆ�΁A<span class="en">10writeback</span>�̂悤�ɂ����<span class="en">find</span>�v���O�C�������O�Ɏ��s�����悤�ɂȂ�܂��B�ŏ���<span class="en">find</span>�v���O�C���̖��O����<span class="en">05find</span>�ɕύX���܂��B����̃v���O�C���̓�����Ō�ɂ���ꍇ�ɂ́A<span class="en">999999lastplugin</span>�̂悤�ɑ傫�Ȕԍ���t���܂��B</p>
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>特定の順番でプラグインを実行させるには?</h2><p>プラグインは標準でアルファベット順で実行されます（<span class="en">file</span>は<span class="en">writeback</span>の前に実行されます）。プラグインの実行順序を変更するためのもっとも簡単な方法は、番号を付けることです。<span class="en">writeback</span>プラグインの名前を変更し、例えば、<span class="en">10writeback</span>のようにすると<span class="en">find</span>プラグインよりも前に実行されるようになります。最初に<span class="en">find</span>プラグインの名前をを<span class="en">05find</span>に変更します。特定のプラグインの動作を最後にする場合には、<span class="en">999999lastplugin</span>のように大きな番号を付けます。</p>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/plugins<br>
 Date: 2003-09-07</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_particular_order_plugin.html
+++ b/faq_particular_order_plugin.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_particular_order_plugin.html
+++ b/faq_particular_order_plugin.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - 特定の順番でプラグインを実行させるには？</title>
 

--- a/faq_post_by_email.html
+++ b/faq_post_by_email.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,“ú–{Œê,–|–ó">
-<title>blosxomƒTƒCƒg‚Ì“ú–{Œê–ó::FAQ - ƒƒO‚ðƒ[ƒ‹‚Åì¬‚·‚é‚±‚Æ‚Í‚Å‚«‚Ü‚·‚©H</title>
+<meta name="keywords" content="blosxom,æ—¥æœ¬èªž,ç¿»è¨³">
+<title>blosxomã‚µã‚¤ãƒˆã®æ—¥æœ¬èªžè¨³::FAQ - ãƒ­ã‚°ã‚’ãƒ¡ãƒ¼ãƒ«ã§ä½œæˆã™ã‚‹ã“ã¨ã¯ã§ãã¾ã™ã‹ï¼Ÿ</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,61 +11,61 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::“ú–{Œê–ó</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="ƒtƒŒ[ƒ€">
+<div id="header"><span class="en">blosxom</span>::æ—¥æœ¬èªžè¨³</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="ãƒ•ãƒ¬ãƒ¼ãƒ ">
 <tbody>
 <tr>
 <td id="menu">
-<h4>–|–ó‚É‚Â‚¢‚Ä</h4>
+<h4>ç¿»è¨³ã«ã¤ã„ã¦</h4>
 <ul class="mid">
-<li><a href="index.html" title="‚¨“Ç‚Ý‚­‚¾‚³‚¢">‚¨“Ç‚Ý‚­‚¾‚³‚¢</a></li>
+<li><a href="index.html" title="ãŠèª­ã¿ãã ã•ã„">ãŠèª­ã¿ãã ã•ã„</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom‚É‚Â‚¢‚Ä"><span class="en">Blosxom</span>‚É‚Â‚¢‚Ä</a></li>
-<li><a href="features.html" title="Blosxom‚Ì‹@”\">‹@”\</a></li>
-<li><a href="colophon.html" title="‰œ•t">‰œ•t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ƒjƒ…[ƒX">ƒjƒ…[ƒXi‰pŒêj</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="ƒ[ƒŠƒ“ƒOƒŠƒXƒg">ƒ[ƒŠƒ“ƒOƒŠƒXƒgi‰pŒêj</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="Šñ‘¡">Šñ‘¡i‰pŒêj</a></li>
+<li><a href="about.html" title="Blosxomã«ã¤ã„ã¦"><span class="en">Blosxom</span>ã«ã¤ã„ã¦</a></li>
+<li><a href="features.html" title="Blosxomã®æ©Ÿèƒ½">æ©Ÿèƒ½</a></li>
+<li><a href="colophon.html" title="å¥¥ä»˜">å¥¥ä»˜</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ãƒ‹ãƒ¥ãƒ¼ã‚¹">ãƒ‹ãƒ¥ãƒ¼ã‚¹ï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆ">ãƒ¡ãƒ¼ãƒªãƒ³ã‚°ãƒªã‚¹ãƒˆï¼ˆè‹±èªžï¼‰</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="å¯„è´ˆ">å¯„è´ˆï¼ˆè‹±èªžï¼‰</a></li>
 </ul>
-<h4>ƒ†[ƒUŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>ãƒ¦ãƒ¼ã‚¶å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom‚ÌŠT—v">ŠT—v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom‚ÌƒCƒ“ƒXƒg[ƒ‹">ƒCƒ“ƒXƒg[ƒ‹</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom‚ÌÝ’è">ŠÂ‹«Ý’è</a></li>
-<li><a href="doc_users_blog.html" title="ƒEƒFƒuƒƒO">ƒEƒFƒuƒƒO</a></li>
-<li><a href="doc_users_view.html" title="ƒEƒFƒuƒƒO‚Ì‰{——">‰{——</a></li>
-<li><a href="doc_users_flavour.html" title="ƒtƒŒ[ƒo[">ƒtƒŒ[ƒo[</a></li>
-<li><a href="doc_users_syndicate.html" title="ƒVƒ“ƒWƒP[ƒg">ƒVƒ“ƒWƒP[ƒg</a></li>
-<li><a href="doc_users_plugins.html" title="ƒvƒ‰ƒOƒCƒ“">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="plugin_registry.html" title="ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW">ƒvƒ‰ƒOƒCƒ““o˜^ƒy[ƒW</a></li>
-<li><a href="doc_users_configure_static.html" title="Ã“I•\Ž¦‚ÌÝ’è">Ã“I•\Ž¦‚ÌÝ’è</a></li>
-<li><a href="faq.html" title="—Ç‚­‚ ‚éŽ¿–â"><span class="en">faq</span></a></li>
-<li>Žg—p—á*</li>
+<li><a href="doc_users_overview.html" title="Blosxomã®æ¦‚è¦">æ¦‚è¦</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomã®ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«">ã‚¤ãƒ³ã‚¹ãƒˆãƒ¼ãƒ«</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomã®è¨­å®š">ç’°å¢ƒè¨­å®š</a></li>
+<li><a href="doc_users_blog.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°">ã‚¦ã‚§ãƒ–ãƒ­ã‚°</a></li>
+<li><a href="doc_users_view.html" title="ã‚¦ã‚§ãƒ–ãƒ­ã‚°ã®é–²è¦§">é–²è¦§</a></li>
+<li><a href="doc_users_flavour.html" title="ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼">ãƒ•ãƒ¬ãƒ¼ãƒãƒ¼</a></li>
+<li><a href="doc_users_syndicate.html" title="ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ">ã‚·ãƒ³ã‚¸ã‚±ãƒ¼ãƒˆ</a></li>
+<li><a href="doc_users_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="plugin_registry.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²ãƒšãƒ¼ã‚¸</a></li>
+<li><a href="doc_users_configure_static.html" title="é™çš„è¡¨ç¤ºã®è¨­å®š">é™çš„è¡¨ç¤ºã®è¨­å®š</a></li>
+<li><a href="faq.html" title="è‰¯ãã‚ã‚‹è³ªå•"><span class="en">faq</span></a></li>
+<li>ä½¿ç”¨ä¾‹*</li>
 </ul>
-<h4>ŠJ”­ŽÒŒü‚¯ƒhƒLƒ…ƒƒ“ƒg</h4>
+<h4>é–‹ç™ºè€…å‘ã‘ãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆ</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="ŠT—vFŠJ”­ŽÒŒü‚¯">ŠT—v</a></li>
-<li><a href="doc_dev_plugins.html" title="ƒvƒ‰ƒOƒCƒ“FŠJ”­ŽÒŒü‚¯">ƒvƒ‰ƒOƒCƒ“</a></li>
-<li><a href="doc_dev_plugin_register.html" title="ŠJ”­ŽÒŒü‚¯Fƒvƒ‰ƒOƒCƒ““o˜^">ƒvƒ‰ƒOƒCƒ“‚Ì“o˜^</a></li>
+<li><a href="doc_dev_overview.html" title="æ¦‚è¦ï¼šé–‹ç™ºè€…å‘ã‘">æ¦‚è¦</a></li>
+<li><a href="doc_dev_plugins.html" title="ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ï¼šé–‹ç™ºè€…å‘ã‘">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³</a></li>
+<li><a href="doc_dev_plugin_register.html" title="é–‹ç™ºè€…å‘ã‘ï¼šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ç™»éŒ²">ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç™»éŒ²</a></li>
 </ul>
-<h4>ƒ_ƒEƒ“ƒ[ƒh</h4>
+<h4>ãƒ€ã‚¦ãƒ³ãƒ­ãƒ¼ãƒ‰</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="‘S‚Ä‚Ìl‚Ö">‘S‚Ä‚Ìl‚Ö</a></li>
-<li><a href="license.html" title="ƒ‰ƒCƒZƒ“ƒX">ƒ‰ƒCƒZƒ“ƒX</a></li>
-<li>‹¤“¯§ì*</li>
+<li><a href="downloads.html" title="å…¨ã¦ã®äººã¸">å…¨ã¦ã®äººã¸</a></li>
+<li><a href="license.html" title="ãƒ©ã‚¤ã‚»ãƒ³ã‚¹">ãƒ©ã‚¤ã‚»ãƒ³ã‚¹</a></li>
+<li>å…±åŒåˆ¶ä½œ*</li>
 </ul>
-<p>*ŒöŽ®ƒTƒCƒg‚Å–¢Ž·•M</p>
+<p>*å…¬å¼ã‚µã‚¤ãƒˆã§æœªåŸ·ç­†</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>ƒƒO‚ðƒ[ƒ‹‚Åì¬‚·‚é‚±‚Æ‚Í‚Å‚«‚Ü‚·‚©?</h2><p>‚Å‚«‚Ü‚·B<a href="http://www.pipetree.com/testwiki/Blosmail" class="en">blosmail</a>‚ª‚±‚ê‚ðI‚Ý‚És‚Á‚Ä‚¢‚Ü‚·B</p>
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>ãƒ­ã‚°ã‚’ãƒ¡ãƒ¼ãƒ«ã§ä½œæˆã™ã‚‹ã“ã¨ã¯ã§ãã¾ã™ã‹?</h2><p>ã§ãã¾ã™ã€‚<a href="http://www.pipetree.com/testwiki/Blosmail" class="en">blosmail</a>ãŒã“ã‚Œã‚’å·§ã¿ã«è¡Œã£ã¦ã„ã¾ã™ã€‚</p>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/posting<br>
 Date: 2003-09-07</p>
-</div><p class="nextLink"><a href="#top">[ƒy[ƒW‚Ìæ“ª‚Ö–ß‚é]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ãƒšãƒ¼ã‚¸ã®å…ˆé ­ã¸æˆ»ã‚‹]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/faq_post_by_email.html
+++ b/faq_post_by_email.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - ログをメールで作成することはできますか？</title>
 

--- a/faq_post_by_email.html
+++ b/faq_post_by_email.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_specify_encoding.html
+++ b/faq_specify_encoding.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - 特定のフレーバーで文字エンコードを特定するにはどうするのですか？</title>
 

--- a/faq_specify_encoding.html
+++ b/faq_specify_encoding.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/faq_specify_encoding.html
+++ b/faq_specify_encoding.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - ����̃t���[�o�[�ŕ����G���R�[�h����肷��ɂ͂ǂ�����̂ł����H</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - 特定のフレーバーで文字エンコードを特定するにはどうするのですか？</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,64 +11,64 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>����̃t���[�o�[�ŕ����G���R�[�h����肷��ɂ͂ǂ�����̂ł����H</h2>
-<p>�W���̕����G���R�[�h��<span class="en">ISO-8859-1</span>�ł��B�����ύX����ɂ́A�P�Ƀt���[�o�[��<strong class="se">content_type.{flavour}</strong>�t�@�C����<strong class="se">content-type</strong>�̍s�̍Ō�ɃG���R�[�h��ǉ����܂��B�Ⴆ�΁A�M���̕W����<span class="en">HTML</span>��<span class="en">UTF-8</span>�G���R�[�h�ł���Ǝw�肷��ɂ�<span class="en">content_type.html</span>���ȉ��̂悤�ɂ��܂��F</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl"><span class="en">FAQ</span></a></h1><h2>特定のフレーバーで文字エンコードを特定するにはどうするのですか？</h2>
+<p>標準の文字エンコードは<span class="en">ISO-8859-1</span>です。これを変更するには、単にフレーバーの<strong class="se">content_type.{flavour}</strong>ファイルの<strong class="se">content-type</strong>の行の最後にエンコードを追加します。例えば、貴方の標準の<span class="en">HTML</span>が<span class="en">UTF-8</span>エンコードであると指定するには<span class="en">content_type.html</span>を以下のようにします：</p><pre class="en">
 text/html; charset=UTF-8
 </pre>
 <div id="author">
 <p class="en">Author: Rael Dornfest<br>
 Category: /faq/header/encoding<br>
 Date: 2003-07-26</p>
-</div><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</div><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/features.html
+++ b/features.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::FAQ - 機能</title>
 

--- a/features.html
+++ b/features.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/features.html
+++ b/features.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::FAQ - �@�\</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::FAQ - 機能</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,71 +11,71 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�@�\</a></h1><ul class="mid">
-<li>����͊��S��<a href="license.html">�t���[</a>�ł��I</li>
-<li><a href="doc_users_install_dynamic.html">15���ȓ�</a>�ŃE�F�u���O���n�߂���̂ł����̐ߖ�ɂȂ�܂��B;-)</li>
-<li><a href="doc_users_install_dynamic.html">�Œ���̓������</a>�����Ȃ��ƌ������Ƃ�<span class="en">Blosxom</span>�͂ǂ��ł����삷��ƌ������Ƃł��B</li>
-<li>�D���ȃe�L�X�g�G�f�B�^�Ń��O��<a href="doc_users_blog.html">����</a>���Ƃ��ł��܂�--<span class="en">BBEdit</span>�A<span class="en">vi</span>�A<span class="en">emacs</span>�A�������c</li>
-<li>���茳�̑S�Ă�<span class="en">OS</span>��<span class="en">Web</span>�T�[�o��<a href="about.html">�g��</a>���Ƃ��ł��܂�--<span class="en">Mac OS X</span>��<span class="en">Apache</span>�A<span class="en">Windows XP</span>��<span class="en">IIS</span></li>
-<li><span class="en">Blosxom</span>���<a href="doc_users_view.html">�����̃E�F�u���O</a>���Ǘ��ł��܂��B</li>
-<li><a href="doc_users_view.html" class="en">permalinks</a>�͓��t�����ɁA����̃��O���w���܂��i������݂����Ȃ��́j�B</li>
-<li><a href="doc_users_view.html">�A�[�J�C�u</a>�͓����ƁA�����ƁA�N���Ƃō쐬�ł��܂��B</li>
-<li><a href="doc_users_flavour.html">�t���[�o�[�i<span class="en">Flavor</span>�j</a>�̓J�X�^�}�C�Y�\�ȃe���v���[�g�V�X�e���ł��B</li>
-<li>�E�F�u���O�̕\���ɂ�<a href="doc_users_view.html">���I</a>�i���̓s�x�v���O�����ŕ\���j�A<a href="doc_users_configure_static.html">�ÓI</a>�i�t�@�C���Ƃ��Ă��炩���ߗp�ӂ������̂�\���j��I���ł��܂��B</li>
-<li><a href="doc_users_syndicate.html"><span class="en">RSS</span>�V���W�P�[�g</a>�B</li>
-<li><a href="doc_users_syndicate.html">�������i�T�C�Y��10K�ȉ��A�R�[�h�̍s����150�s�ȉ��j�A�y�ʂł��B</a></li>
-<li>�m�I�ȃf�t�H���g�����B</li>
-<li>��������Ɗo����ׂ����Ƃ͍ŏ��ōςނɂ�������炸�A�@�\�͏\���ŋ��͂�<a href="doc_users_plugins.html">�v���O�C��</a>�V�X�e���ɂ���ċ����ׂ��g�����������Ă��܂��B<a href="plugin_registry.html">�v���O�C���o�^�y�[�W</a>�ł͂ǂ�����ƃv���O�C�����Љ�Ă��܂��B</li>
-</ul><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<td id="contents"><h1><a name="top" class="bl">機能</a></h1><ul class="mid">
+<li>入手は完全に<a href="license.html">フリー</a>です！</li>
+<li><a href="doc_users_install_dynamic.html">15分以内</a>でウェブログを始められるのでお金の節約になります。;-)</li>
+<li><a href="doc_users_install_dynamic.html">最低限の動作条件</a>しかないと言うことは<span class="en">Blosxom</span>はどこでも動作すると言うことです。</li>
+<li>好きなテキストエディタでログを<a href="doc_users_blog.html">書く</a>ことができます--<span class="en">BBEdit</span>、<span class="en">vi</span>、<span class="en">emacs</span>、メモ帳…</li>
+<li>お手元の全ての<span class="en">OS</span>と<span class="en">Web</span>サーバを<a href="about.html">使う</a>ことができます--<span class="en">Mac OS X</span>と<span class="en">Apache</span>、<span class="en">Windows XP</span>と<span class="en">IIS</span></li>
+<li><span class="en">Blosxom</span>一つで<a href="doc_users_view.html">複数のウェブログ</a>を管理できます。</li>
+<li><a href="doc_users_view.html" class="en">permalinks</a>は日付を元に、特定のログを指します（しおりみたいなもの）。</li>
+<li><a href="doc_users_view.html">アーカイブ</a>は日ごと、月ごと、年ごとで作成できます。</li>
+<li><a href="doc_users_flavour.html">フレーバー（<span class="en">Flavor</span>）</a>はカスタマイズ可能なテンプレートシステムです。</li>
+<li>ウェブログの表示には<a href="doc_users_view.html">動的</a>（その都度プログラムで表示）、<a href="doc_users_configure_static.html">静的</a>（ファイルとしてあらかじめ用意したものを表示）を選択できます。</li>
+<li><a href="doc_users_syndicate.html"><span class="en">RSS</span>シンジケート</a>。</li>
+<li><a href="doc_users_syndicate.html">小さく（サイズは10K以下、コードの行数は150行以下）、軽量です。</a></li>
+<li>知的なデフォルト処理。</li>
+<li>動作条件と覚えるべきことは最小で済むにもかかわらず、機能は十分で強力な<a href="doc_users_plugins.html">プラグイン</a>システムによって驚くべき拡張性を持っています。<a href="plugin_registry.html">プラグイン登録ページ</a>ではどっさりとプラグインを紹介しています。</li>
+</ul><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳</title>
 

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,94 +11,94 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
 
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">���ǂ݂�������</a></h1><p>���̃y�[�W��<a href="http://www.blosxom.com/" title="blosxom :: the zen of blogging"><span class="en">blosxom :: the zen of blogging</span></a>��|�󂵂����̂ł��B<span class="en">blosxom</span>�̍�҂ł�������T�C�g�̊Ǘ��҂ł�����<span class="en">Rael Dornfest</span>����̋��𓾂č쐬���Ă��܂��B</p><h2>�Ȃɂ��ƎQ�l�ɂȂ�T�C�g</h2><dl> 
+<td id="contents"><h1><a name="top" class="bl">お読みください</a></h1><p>このページは<a href="http://www.blosxom.com/" title="blosxom :: the zen of blogging"><span class="en">blosxom :: the zen of blogging</span></a>を翻訳したものです。<span class="en">blosxom</span>の作者であり公式サイトの管理者でもある<span class="en">Rael Dornfest</span>さんの許可を得て作成しています。</p><h2>なにかと参考になるサイト</h2><dl> 
 <dt><a href="http://www.blosxom.com/"><span class="en">blosxom :: the zen of blogging</span></a></dt>
 <dd>
-<p><span class="en">Blosxom</span>��z�z���Ă�������T�C�g�ł��i�p��j�B</p>
+<p><span class="en">Blosxom</span>を配布している公式サイトです（英語）。</p>
 </dd>
 <dt><a href="http://cgi.no-ip.org/cgi-bin/blosxom/blosxom.cgi"><span class="en">C.G.I.:blosxom</span></a></dt>
 <dd>
-<p><span class="en">Blosxom</span>�̓��{��Ή��C���ł���{��Ή����v���O�C���������J����Ă���܂��B���{��<span class="en">blosxom</span>���[�U�̃��X�g�����J����Ă���̂ŁA���[�U�̎g�����𒭂߂Ă݂�̂��ʔ�����������܂���B</p>
+<p><span class="en">Blosxom</span>の日本語対応修正版や日本語対応化プラグイン等を公開されております。日本の<span class="en">blosxom</span>ユーザのリストを公開されているので、ユーザの使い方を眺めてみるのも面白いかもしれません。</p>
 </dd>
 <dt><a href="http://blosxom.org/"><span class="en">blosxom.org</span></a></dt>
 <dd>
-<p><span class="en">Blosxom</span>�̓��{�ꃊ�\�[�X�����ꏊ�ł��B</p>
+<p><span class="en">Blosxom</span>の日本語リソース貯蔵場所です。</p>
 </dd>
 <dt><a href="/"><span class="en">hail2u.net</span></a></dt>
 <dd>
-<p><span class="en">Blosxom</span>�ɂ��Ă��낢�뎎����Ă���T�C�g�ł��B<a href="/archives/bsk.html#resources"><span class="en">blosxom starter kit</span></a>�ƌ������̂�p�ӂȂ����Ă��܂��B���ꂩ��<span class="en">Blosxom</sapn>���n�߂����Ƃ������ɂ͓��ɗǂ��̂ł͂Ȃ��ł��傤���B���ɂ�<span class="en">Weblog</span>�͓��ɕK���ł��B</p>
+<p><span class="en">Blosxom</span>についていろいろ試されているサイトです。<a href="/archives/bsk.html#resources"><span class="en">blosxom starter kit</span></a>と言うものを用意なさっています。これから<span class="en">Blosxom</sapn>を始めたいという方には特に良いのではないでしょうか。他にも<span class="en">Weblog</span>は特に必見です。</p>
 </dd>
-</dl><h2>��҂��g���Ă݂����z</h2><p><a href="myinstall.html">���炾��Ə����Ă���̂Ńy�[�W�𕪂��܂����B</a></p>
-<h2>�悭�͂Ȃ�����</h2><dl>
-<dt>���̓��{����<span class="en">Blosxom</span>�łǂ�����č���Ă���̂ł����H</dt>
-<dd><p>���̓��{���͑S��<span class="en">HTML</span>�ŏ����Ă��܂��B<span class="en">Blosxom</span>�͎g���Ă��܂���B</p></dd>
+</dl><h2>訳者が使ってみた感想</h2><p><a href="myinstall.html">だらだらと書いているのでページを分けました。</a></p>
+<h2>よくはない質問</h2><dl>
+<dt>この日本語訳は<span class="en">Blosxom</span>でどうやって作っているのですか？</dt>
+<dd><p>この日本語訳は全て<span class="en">HTML</span>で書いています。<span class="en">Blosxom</span>は使っていません。</p></dd>
 </dl>
-<h2>��҂���̂�����</h2>
+<h2>訳者からのご注意</h2>
 <ul class="mid">
-<li>2006�N8��28���F�t�H���g�𓝈ꂷ��Ȃ�CSS�Ɏ�����܂����B</li>
-<li>2004�N5��10���FGoogle�ł̌�����ǉ����܂����B�ꉞ�A���̓��{���y�[�W�������q�b�g����悤�ɂ�������ł����A�����łȂ�������AGoogle�̃C���f�b�N�X�ɖ���������ȂǁA�Ӑ}�����������ʂɂȂ�Ȃ��ꍇ������܂��̂ł��������������B���ƁA�����̓g�b�v�i�u���ǂ݂��������v�̃y�[�W�j�݂̂ɂ��Ă��܂��B</li>
-<li>2003�N11��23���F�ق�̏����̍Z���ƁA<span class="en">FAQ</span>�̒ǉ����s���܂����B������傫�����A���̑������A�����ڂ�ς��܂����B</li>
-<li>�����T�C�g�̓��e��2003�N8��9���̂��̂ł��B�����T�C�g�͓��X���������Ă���̂ŁA���̓��{��T�C�g�̍X�V���ǂ����Ȃ��\�����傢�ɂ���܂��B�ƌ������������A�K�v���������/�C�����̂�Ȃ���΂ق����炩���B</li>
-<li>��҂͉p�ꂪ�]�蓾�ӂł͖����̂Łi�΁j�A���₵�傤���Ȃ��\���A��ԈႢ�Ȃǂ��i���Ȃ�ƌ������c��j�ɂ���܂��B�܂��啝�ɈӖ󂵂Ă���i�Ǝv���Ă���j�ꍇ�₿�������ȗ����Ă���Ƃ��������܂��B������ӂ܂�����ŁA���^�S�A�z���͂𓭂����Ă��ǂ݂��������B</li>
-<li>���p��₠����i�T�[�o��<span class="en">OS</span>�Ȃǁj�̐����Ɋւ��Ė�҂̒m���s���△�m�̂��߂ɈӖ��s����S���Ԉ���Ă���ӏ�������Ǝv���܂��B</li>
-<li>�p�P���p���̈Ӗ��������炸�A���̂܂܂̒P���p���A�J�^�J�i�ǂ݂ɂȂ��Ă���ӏ�������܂��B</li>
-<li>�����T�C�g�̓����Ƃ��ē������e�������̃y�[�W�ɑ��݂��邱�Ƃ��悭����܂��B���̓��{���T�C�g�ł͈ꕔ���C�����Ă��S�Ẵy�[�W�ɔ��f�ł��Ă��Ȃ���������܂��i�K������ɈႢ�Ȃ��A����A���ɕ������Ă���j�B</li>
-<li>���̃T�C�g�̕s���Ɋւ���<span class="en">Rael Dornfest</span>����ɖ₢���킹��A���͂��Ȃ��ŉ������B</li>
-<li>�ŐV�̏��Ɋւ��Ă͌����T�C�g<a href="http://www.blosxom.com/" title="blosxom :: the zen of blogging"><span class="en">blosxom :: the zen of blogging</span></a>�������������B</li>
-<li>���̃T�C�g�̖|��ɏ]����<span class="en">Blosxom</span>���C���X�g�[���A�^�p���ĉ����s����N�������Ƃ��Ă���҂͐ӔC�𕉂����˂܂��B�܂�<span class="en">Rael Dornfest</span>����ɂ��A�����Ȃ��ŉ������B</li>
-<li>�l�b�g�Ɍ��J����Ƃ��͂܂��A���[�J���̊��Ŏ����Ă݂邱�Ƃ������߂��܂��B</li>
+<li>2006年8月28日：フォントを統一するなどCSSに手を入れました。</li>
+<li>2004年5月10日：Googleでの検索を追加しました。一応、この日本語訳ページが多くヒットするようにしたつもりですが、そうでなかったり、Googleのインデックスに無かったりなど、意図した検索結果にならない場合もありますのでご了承ください。あと、検索はトップ（「お読みください」のページ）のみにつけています。</li>
+<li>2003年11月23日：ほんの少しの校正と、<span class="en">FAQ</span>の追加を行いました。文字を大きくし、その他多少、見た目を変えました。</li>
+<li>公式サイトの内容は2003年8月9日のものです。公式サイトは日々成長をしているので、この日本語サイトの更新が追いつかない可能性が大いにあります。と言うよりも多分、必要が無ければ/気分がのらなければほったらかし。</li>
+<li>訳者は英語が余り得意では無いので（笑）、誤訳やしょうもない表現、大間違いなどが（かなりと言うか膨大）にあります。また大幅に意訳している（と思っている）場合やちゃっかり省略しているところもあります。それをふまえた上で、懐疑心、想像力を働かせてお読みください。</li>
+<li>専門用語やある環境（サーバや<span class="en">OS</span>など）の説明に関して訳者の知識不足や無知のために意味不明や全く間違っている箇所があると思います。</li>
+<li>英単語や英文の意味が分からず、そのままの単語や英文、カタカナ読みになっている箇所があります。</li>
+<li>公式サイトの特徴として同じ内容が複数のページに存在することがよくあります。この日本語訳サイトでは一部を修正しても全てのページに反映できていない事があります（必ずあるに違いない、いや、既に分かっている）。</li>
+<li>このサイトの不備に関して<span class="en">Rael Dornfest</span>さんに問い合わせや連絡はしないで下さい。</li>
+<li>最新の情報に関しては公式サイト<a href="http://www.blosxom.com/" title="blosxom :: the zen of blogging"><span class="en">blosxom :: the zen of blogging</span></a>をご覧下さい。</li>
+<li>このサイトの翻訳に従って<span class="en">Blosxom</span>をインストール、運用して何か不具合が起こったとしても訳者は責任を負いかねます。また<span class="en">Rael Dornfest</span>さんにも連絡しないで下さい。</li>
+<li>ネットに公開するときはまず、ローカルの環境で試してみることをお勧めします。</li>
 </ul>
-<p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+<p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/license.html
+++ b/license.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::ライセンス</title>
 

--- a/license.html
+++ b/license.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::���C�Z���X</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::ライセンス</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,58 +11,58 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">���C�Z���X</a></h1><p><span class="en">Blosxom<br>
+<td id="contents"><h1><a name="top" class="bl">ライセンス</a></h1><p><span class="en">Blosxom<br>
 Copyright 2003, Rael Dornfest </span><br>
-�@���Ȃ�l�X����p�̔����������̃\�t�g�E�F�A�̃R�s�[�Ɗ֘A�����t�@�C���i<span class="en">&quot;Software&quot;</span>�ƌĂԁj����肵�A��������<span class="en">Software></span>�������A����Ɋւ��ė��p�A�R�s�[�A���ρA�����A�o�ŁA�z�z�A<span class="en">Software</span>�̃R�s�[�̔̔��Ɋւ��Č����̐������܂߂邱�Ɩ����A�������s���l�Ɉȉ��̏����ɂċ���^���܂��B</p><p class="en">Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: </p><p>��L����\�L�Ƌ��\�L�͑S�ẴR�s�[�����Ă���<span class="en">Software</span>�̔h�����Ɋ܂߂邱�ƂƂ��܂��B</p><p class="en">THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. </p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+如何なる人々も費用の発生無くこのソフトウェアのコピーと関連文書ファイル（<span class="en">&quot;Software&quot;</span>と呼ぶ）を入手し、制限無く<span class="en">Software></span>を扱い、これに関して利用、コピー、改変、統合、出版、配布、<span class="en">Software</span>のコピーの販売に関して権限の制限を含めること無く、それらを行う人に以下の条件にて許可を与えます。</p><p class="en">Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: </p><p>上記著作表記と許可表記は全てのコピーそしてこの<span class="en">Software</span>の派生物に含めることとします。</p><p class="en">THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. </p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/license.html
+++ b/license.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/myinstall.html
+++ b/myinstall.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::訳者が使ってみた感想</title>
 

--- a/myinstall.html
+++ b/myinstall.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::��҂��g���Ă݂����z</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::訳者が使ってみた感想</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,64 +11,64 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">��҂��g���Ă݂����z</a></h1><p><span class="en">Blosxom</span>�̓v���o�C�_�ł������񋟂��Ă��� <span class="en">Perl</span>�����삷��Ύg����A�ƌ����e�Ղ������͂ł��B�l�C�̂���<span class="en">Movable Type</span>����<span class="en">Blog</span>�V�X�e���̓f�[�^�x�[�X�T�[�o��K�v�Ƃ�����ƁA�ʏ�́i���{�́j�v���o�C�_�ł͗��p����̂����������Ƃ�����܂����A<span class="en">Blosxom</span>�͑����̏ꍇ�A���삷��Ǝv���܂��B</p><h2>�C���X�g�[��</h2><p>�C���X�g�[���͌��\�ȒP�ł��B�f���X�N���v�g�ȂǁA�ǂ����̔z�z�T�C�g���������Ă��Đݒu������������Ƃ����̂ł���ΎG��������ł��傤�B<span class="en">Perl</span>�Ŏ���A�v���P�[�V�������쐬���Ă���̂ł���΂Ȃ�����ł��B�Ⴆ���̌o���������Ă��A�X�N���v�g�t�@�C���i<span class="en">blosxom.cgi</span>�j���e�L�X�g�G�f�B�^�ŊJ���Ă���𑽏��ҏW����E�C�A�����ăv���o�C�_���g���ꍇ�ɂ̓v���o�C�_�̊��̐�����������x�����ł���ΐݒu�ł���Ǝv���܂��B�v���o�C�_�̐�����S�������ł��Ȃ��ꍇ�́c�����E�F�u�Œ��ׂ邩������l�ɕ����Ă݂ĉ������B</p><p><span class="en">Blosxom</span>���g���ƌ������Ƃ͋��炭�A�����̏ꍇ�̓C���^�[�l�b�g�Ɍ��J���邱�Ƃ��ړI���Ǝv���܂��B����ɂ̓v���o�C�_�̃X�y�[�X���g�����ƂɂȂ�ꍇ���������Ǝv���܂��B�܂��̓v���o�C�_�Ńz�[���y�[�W��ݒu�ł��āA���Ǝ���<span class="en">CGI</span>�X�N���v�g���g�����Ƃ��ł��邩���m�F���Ă��������B����̓v���o�C�_�̗��p�������z�[���y�[�W�ɏ�����Ă��܂��B�z�[���y�[�W�����ĂȂ��̂ł���Β��߂邵������܂��񂪁A���ꂪ�\�ŁA�Ǝ�<span class="en">CGI</span>�X�N���v�g���g�p�ł���ƂȂ�΂��̂قƂ�ǂ�<span class="en">Perl</span>�����p�ł���Ǝv���܂��̂�<span class="en">Blosxom</span>������ł���\���������Ȃ�܂��B</p><p>�v���o�C�_�̐����ɂ��������āA<span class="en">Perl</span>�ւ̃p�X���m�F���܂��B����� <span class="en">#!/usr/perl/bin/perl</span> �݂����Ȃ�ł��B�����<span class="en">blosxom.cgi</span>��1�s�ڂŊm�F���āA����Ă���Ώ��������܂��B</p><p>���ɁA�T�[�o�̂ǂ̃f�B���N�g���i�t�H���_�j��<span class="en">blosxom.cgi</span>��u���Ηǂ��̂��A�v���o�C�_�̐����ɏ]���Ă��������B���̏ꏊ��<span class="en">cgi-bin</span>�ł�������A�M���̃f�B���N�g���̂ǂ��ł��\��Ȃ����A�v���o�C�_�ɂ���ĈقȂ�ꍇ������܂��B</p>
-<p>�Ǝ�<span class="en">CGI</span>�X�N���v�g���ǂ��ɂ����Ηǂ����킩�����B�ł��A�����Ŗ��ɂȂ邩���m��Ȃ�����������܂��B����́A���O�f�[�^��u���f�B���N�g���̐�΃p�X�ł��B<span class="en">Blosxom</span>�̐ݒ��<span class="en">$datadir</span>�ɐݒ肷��d�v�Ȃ��̂ł��B��΃p�X�͗Ⴆ�΂��̃y�[�W��<span class="en">URL</span>�̂悤�� <span class="en">&quot;/www.yk.rim.or.jp/~hoge/blosxom/&quot;</span>�̂悤�Ȍ`�Ƃ͑����̏ꍇ�A�قȂ��Ă��܂��B<span class="en">/home/hoge/public_html/blosxom</span>�̂悤�ɂȂ��Ă��邩���m��܂���i�����l�b�g�ł͂���Ƃ͂��Ȃ�قȂ���̂ɂȂ��Ă��܂��j�B�v���o�C�_�̗��p�������z�[���y�[�W�̐�����ǂ��ǂ�ł��������B�����<span class="en">$datadir</span>�ɓK�؂ɐݒ�ł��Ȃ��ƁA<span class="en">Blosxom</span>�̓��O�̏ꏊ�������邱�Ƃ��ł��܂���B</p>
-<p>�f�B���N�g���i�t�H���_�j��<span class="en">blosxom.cgi</span>��u������A<span class="en">$datadir</span>�Ŏw�肵�����O�ۊǃf�B���N�g�������̉��ɍ쐬���A<span class="en">blosxom.cgi</span>�̃p�[�~�b�V�������m�F���Ă��������B�p�[�~�b�V������<span class="en">blosxom.cgi</span>��N�����s�����邩���w�肷����̂ł��B�v���o�C�_�ɂ���ĈقȂ�܂��B���̃����l�b�g�ł�<span class="en">700</span>�ɂȂ��Ă��܂����A�v���o�C�_�ɂ���Ă�<span class="en">777</span>�ł������肷�邩������܂���B������v���o�C�_�̐�����ǂ�ł��������B</p><p><span class="en">Blosxom</span>���g�����E�F�u���O��\�����悤�Ƃ���<span class="en">&quot;Internal Server Error&quot;</span>�i�G���[�Ɋւ�����́j�ƕ\�����ꂽ�ꍇ�́A�ݒ肪�Ԉ���Ă���\��������܂��B�ݒ肪�Ԉ���Ă��Ȃ��Ă��v���o�C�_�ɂ���Ă̓G���[�ɂȂ�ꍇ������܂��̂ŁA���̏ꍇ�̓v���o�C�_�ɖ₢���킹�Ă݂Ă��������B</p><div class="figure"><img src="image/directory.gif" width="260" height="400" alt="�f�B���N�g���K�w"></div><h2>���O</h2><p><span class="en">Blosxom</span>�P�̂ł̓��O���쐬�A�ҏW�A�폜�ƌ������@�\�͒񋟂��Ă��܂���B<a href="plugin_registry.html" class="en">wikiedish</a>�̂悤�ȃv���O�C����p����ƃu���E�U�ł������s�����Ƃ��ł���݂����ł����A��{�̓e�L�X�g�G�f�B�^���g���܂��B<span class="en">Mac</span>��<span class="en">Windows</span>�A<span class="en">Unix</span>�n�W���̃e�L�X�g�G�f�B�^���g������A���̑��̃T�[�h�p�[�e�B���̃e�L�X�g�G�f�B�^���g���܂��i�����̃G���R�[�h��ς���ꍇ�͂���ɑΉ����Ă���e�L�X�g�G�f�B�^���g���Ă��������j�B�e�L�X�g�G�f�B�^�Ń��O���쐬������A<span class="en">FTP</span>�N���C�A���g�\�t�g�����g���ăT�[�o�ɃA�b�v���[�h����ƁA<span class="en">Blosxom</span>�͂��������Ɍ����ĕ\�����Ă���܂��B�폜�͂��̃t�@�C�����폜���邱�Ƃł��B</p><p>���O�̍쐬�ɂ�1�A���܂肪����܂��B�ŏ���1�s���^�C�g���i�薼�j�ɂȂ�ƌ������Ƃł��B2�s�ڂ���Ō�܂ł͖{���ɂȂ�܂��B��������1�s�ڂ���{�����n�߂Ă��܂��ƁA�u���E�U�Ō����Ƃ��ɔ��ɒ����^�C�g���ƂȂ��ĕ\������Ă��܂��܂��B</p><h2>�t���[�o�[</h2><p><span class="en">Blosxom</span>�ł̓t���[�o�[�i<span class="en">Flavour</span>�j�ƌĂ΂����̂��g���ăy�[�W��&quot;������&quot;��ύX���܂��B</p><p>
-�t���[�o�[�Ƃ͑��̃V�X�e���ł̓e���v���[�g��e�[�}���ƌĂ΂�Ă�����̂ŁA�y�[�W�̌����ڂ����߂���̂ł��B<span class="en">Blosxom</span>�����T�C�g�̐������ł�&quot;����&quot;��&quot;��&quot;�ȂǁA�{���̉Ԃł���&quot;�u���b�T��&quot;�ɂȂ��炦�ĕ\�����Ă��镔��������܂��B�܂��ɋM���̃y�[�W��&quot;����i�����ځj&quot;������킷���̂�&quot;�t���[�o�[&quot;�ł��B<span class="en">Blosxom</span>�ł͋M���Ǝ��̃t���[�o�[���쐬���邱�Ƃ��A���������������ނ��p�ӂ��ăy�[�W�ɂ���Ďg��������ƌ������Ƃ��\�ł��B</p><p><span class="en">Blosxom</span>�̃f�t�H���g�̃t���[�o�[��<span class="en">Blosxom</span>���́i<span class="en">blosxom.cgi</span>�j�ɏ�����Ă��܂��B<span class="en">Blosxom</span>���C���X�g�[�����ď��߂ĕ\������錩���ڂ�����ł��B<span class="en">Blosxom</span>�͂��̃t���[�o�[�ɏ]���ău���E�U�ɕ\������錩���ڂ����肵�Ă��܂��i�u���E�U�Ƀf�[�^�𑗂�܂��j�B�������A<span class="en">blosxom.cgi</span>�ɏ����ꂽ�t���[�o�[��ύX����̂͑�ςł����A<span class="en">Blosxom</span>�͊O���t�@�C�����t���[�o�[�Ƃ��Ďw��ł���̂œ��ʂȗ��R����������͖��ʂȍ�Ƃł��B�܂���<a href="http://www.blosxom.com/"><span class="en">Blosxom</span>�����T�C�g</a>��<span class="en">Flavour Sampler</span>���_�E�����[�h���āA���̃t�@�C���̓��e���m�F���Ă݂邱�Ƃ������߂��܂��i<span class="en">Blosxom</span>�̃A�[�J�C�u�ɂ̓t���[�o�[�t�@�C���͊܂܂�Ă��܂���B<span class="en">Mac</span>�̃C���X�g�[���łł͊܂܂�Ă���݂����ł����j�B�t���[�o�[�t�@�C����<span class="en">$datadir</span>�ɒu���܂��B�����ăt���[�o�[�t�@�C���̊g���q��<span class="en">blosxom.cgi</span>�̐ݒ�Ŏw�肵�܂��B�w�肷��t���[�o�[�Ƃ́A�t���[�o�[�t�@�C���̊g���q�ł��B�t���[�o�[�t�@�C���̊g���q���t���[�o�[�̖��O�ɂȂ�܂��B��������ƁA���̃t���[�o�[�ŕ\������悤�ɂȂ�܂��B<span class="en">URL</span>�Ɏw�肵�ĕύX������@������܂��B����ɂ��Ă̓��C���̐�����ǂ�ł��������B</p><p>�t���[�o�[�t�@�C�����P�Ȃ�e�L�X�g�t�@�C���ł��B���g��<span class="en">HTML</span>�ƃt���[�o�[�R���|�[�l���g�ƌ������̂ō\������Ă��܂��B������e�L�X�g�G�f�B�^�ŕҏW������A���ɂ��g���q�i�g���q�̓t���[�o�[�̖��O�ɂȂ�܂��j��ς������̂�p�ӂ��邱�ƂŃy�[�W�ɂ���Č����ڂ�ς��邱�Ƃ��ł��܂��B�t���[�o�[�t�@�C����5��ނ�1�Z�b�g�ƂȂ��Ă���A���g�̊�{��<span class="en">HTML</span>�ł����A��������<span class="en">HTML</span>�Ƃ��Ċ������Ă���킯�ł͂���܂���i���<span class="en">&lt;/html&gt;</span>�ŏI����Ă���킯�ł͂���܂���j�B<span class="en">Blosxom</span>�͂���5��ނ̃t�@�C�����q�����킹�čŏI�I�Ƀu���E�U�Ō�����悤�ɂ��܂��B���������āA�Ⴆ�΃z�[���y�[�W�쐬�\�t�g�Ńt���[�o�[���쐬����ɂ́A�ł���<span class="en">HTML</span>�t�@�C����؂�\�肷��K�v������܂��B�܂��A�K�v�ɉ����ēK�؂ȃt���[�o�[�R���|�[�l���g�𖄂ߍ��݂܂��B���̓��L���ɋ�����ƃt���[�o�[�̓y�[�W�̃��C�A�E�g�Ɋւ��Ĉȉ��̂悤�ȍ\���ɂȂ��Ă��܂��i<span class="en">flav</span>�̓t���[�o�[���ł��j�B</p><div class="figure"><img src="image/flavour.gif" width="410" height="280" alt="�t���[�o�[�̍\��"></div><p>�����ɂ���Ă͑S�Ẵt���[�o�[�t�@�C����p�ӂ���͖̂ʓ|��������܂��񂪁i�t�b�^�͂���Ȃ����j�A<span class="en">Blosxom</span>�ł͏�L��5��ނ̃t���[�o�[�t�@�C����K�v�Ƃ��܂��̂ŁA�폜���Ă͂����܂���B</p><p>�t���[�o�[�R���|�[�l���g��$�Ŏn�܂���̂Łi<span class="en">$yr</span>�A<span class="en">$title</span>���j�A<span class="en">Blosxom</span>�̐ݒ��A���t�A���O�̓��e�A�v���O�C�����ɂ���ăt���[�o�[�Ɏ����I�Ɏ�荞�܂����̂ł��B�܂�A<span class="en">$</span>�Ŏn�܂镶���́A�y�[�W�Ƃ��ĕ\�������Ƃ��ɕϊ�����܂��B�Ⴆ�΁A<span class="en">story.flav</span>�̒���<span class="en">$title</span>�Ƃ���΁A<span class="en">$title</span>�͂��̃��O�̃^�C�g���i���O�t�@�C����1�s�ڂ��^�C�g���i�薼�j�ɂȂ�j�ɒu��������ĕ\������܂��B</p><p><span class="en">head</span>�t���[�o�[�̓y�[�W�̍ŏ��̏������w�肷����̂Ȃ̂ŁA<span class="en">&lt;html&gt;</span>�Ȃǂ��܂ނ��ƂɂȂ�܂��B�t��<span class="en">foot</span>�t���[�o�[�̓y�[�W�̍Ō�̏������w�肷��̂�<span class="en">&lt;/html&gt;</span>�ŏI��鎖�ɂȂ�܂��B</p><p><span class="en">content_type</span>�t���[�o�[��<span class="en">head</span>�t���[�o�[��<span class="en">content=&quot;text/html; charset=Shift_JIS&quot;</span>���Ǝw�肵�Ă��܂��Ηp�𐬂��܂��񂪁A�y�[�W�ɂ����<span class="en">XML</span>�������肷��ꍇ��<span class="en">content_type</span>�t���[�o�[��K�X�؂�ւ��܂��B<span class="en">story</span>�t���[�o�[��<span class="en">date</span>�t���[�o�[�͑��̃t���[�o�[�Ƃ͑����A�������قȂ�܂��B���̃t���[�o�[�̓y�[�W�̕\���Ɉ�x�����g���܂����A<span class="en">story</span>�t���[�o�[��<span class="en">date</span>�t���[�o�[�̓��O��\�����邽�߂ɔ����I�Ɏg�p����܂��B�܂�A<span class="en">story</span>�t���[�o�[��<span class="en">date</span>�t���[�o�[�Ŏw�肵�������́A���O���u���E�U�ŕ\�������ۂɁA�S�Ẵ��O�Ɠ��t�ɓK�p����܂��̂ŁA�����N���N���b�N���ăy�[�W��؂�ւ��ĕʂ̃t���[�o�[��K�p����A�ȂǈȊO�̏ꍇ�͕W���ł͗Ⴆ�΁u���ɋ������������O�̌����ڂ����ς���v�ƌ����悤�Ȃ��Ƃ͂ł��܂���i���������K�v�Ȃ���������܂��񂪁j�B</p><p><span class="en">content_type</span>�t���[�o�[�͂ǂ��炩�ƌ����Ɠ���ł����A�y�[�W�̌����ڂ��l�����ꍇ�A<span class="en">head</span>�t���[�o�[�A<span class="en">date</span>�t���[�o�[�A<span class="en">story</span>�t���[�o�[�A<span class="en">foot</span>�t���[�o�[�̏��Ɍq�������čs���āA<span class="en">HTML</span>�Ƃ��Đ������Ă��邱�Ƃ������ɂȂ�܂��i<span class="en">$</span>�Ŏn�܂�R���|�[�l���g�͒u�������܂��j�B</p><h2>�v���O�C��</h2><p><span class="en">Blosxom</span>�P�́i<span class="en">blosxom.cgi</span>�j�ł̓��O�ւ̃R�����g��J�����_�[�ƌ������@�\�͒񋟂��Ă��܂���B���O����t���ɕ\��������x�ł��B�������A�J�����_�[��R�����g�A�g���b�N�o�b�N�ƌ������@�\��&quot;�v���O�C��&quot;�ɂ���Čォ��ǉ����邱�Ƃ��ł��܂��B���̓��L�ł̓J�����_�[�A�J�e�S���A<span class="en">entries_index</span>�A���̑����g���Ă��܂��B</p>
-<p>�v���O�C���ɂ���Ă�<span class="en">Perl</span>�̃o�[�W�����⃂�W���[���Ɉˑ����邱�Ƃ����邩������܂��񂪁A<span class="en">Rael</span>����́u���ʂȏ�����K�v�Ƃ���v���O�C���͍��Ȃ��ŗ~�����v�ƌ����Ă��܂����A�v���O�C���̍쐬�҂�������ӎ����Ă���Ǝv���܂��B�ł��̂ŁA�����A�����ɓ����Ȃ��Ă�������Ƃ����C��������Γ������Ƃ���������Ǝv���܂����A�Ώ��̎d���̓v���O�C���t�@�C���̒����҂̃T�C�g�ɏ�����Ă���Ǝv���܂��B</p><h2>�J�e�S��</h2><p>�p�\�R����<span class="en">Microsoft Word</span>�����g���ĕ������쐬���Ă���ꍇ�A<span class="en">Windows</span>�ł���Ηǂ��A&quot;�}�C�h�L�������g&quot;�ɕ�����ۑ�����ł��傤�B�ꍇ�ɂ���Ă̓}�C�h�L�������g�ɐV���Ƀt�H���_������Ă����ɂ��܂����Ƃ�����ł��傤�B<span class="en">Blosxom</span>�ł̃��O�쐬�͂���Ɏ��Ă��܂��B<span class="en">Blosxom</span>�̐ݒ��<span class="en">$datadir</span>�Ɏw�肵���ꏊ��<span class="en">Windows</span>��&quot;�}�C�h�L�������g&quot;�̂悤�ȏꏊ�ƍl����΁A<span class="en">$datadir</span>�̒��ɐV���Ƀt�H���_�i�f�B���N�g���j������ă��O��ۑ�����ƌ����̂́A��قǂ̃p�\�R���ł̕����ۑ��Ɏ��Ă��܂��B<span class="en">Blosxom</span>�ł�<span class="en">$datadir</span>�ɍ쐬�����t�H���_�i�f�B���N�g���j��&quot;�J�e�S��&quot;�Ƃ��Ĉ����܂��B���̂��߁A���O�̓��e�ɉ����ăt�H���_�i�f�B���N�g���j���쐬����΃��O���J�e�S�����Ƃɐ����ł��܂��B�J�e�S����<span class="en">Blosxom</span>�̕W���̃t���[�o�[�ł͖{���̉��ɕ\������܂��B</p><h2>���̑�</h2><h3>���O�̓��t</h3><p>���O��������<span class="en">FTP</span>�ŃA�b�v���[�h����Ε\�������ƌ����ȒP��������܂����A�����g���Ă݂č��������Ƃ�����܂��B����͉ߋ��̃��O�����������ăA�b�v���[�h����ƁA�A�b�v���[�h�������_�̓��t�⎞�Ԃł��̃��O���\������Ă��܂����Ƃł��B�܂�A��ԏ�ɕ\������Ă��܂����Ƃł��B</p><p>�V�����C���A�܂��͉��M�����ƌ����Ӗ��ł͂�������Ă����l�ɒm�点��Ӗ��ł͗ǂ���������܂���B���������̏ꍇ�͂����������Ȃ������̂ŁA�ǂ�����Ηǂ����ƍl���܂����B�����āA�V�F���𗘗p����X�N���v�g���A�b�v���[�h���Ă�����u���E�U�ŌĂяo���Ɠ��t��ύX����ƌ������̂��ŏ����p���܂������A���̃X�L���ł̓t�@�C�����ɑ΂��ăX�N���v�g����ύX���Ȃ��Ă͂Ȃ�Ȃ������̂ŁA���܂Ƀ��O��ύX�����ꍇ�ɂ͎�����܂������A����đ����̃��O���㏑�����Ă��܂������ɂ͂قƂ�ǐ�]�I�Ɏv���܂����B</p><p>������<span class="en">entries_index</span>�v���O�C���𓱓����܂����B����́A���O�̓��t�����O�t�@�C���Ƃ��ĕۑ����Ă����āA���O���C�����Ă����̃��O�t�@�C���ɏ����ꂽ���t�Ƃ��ĕ\�����Ă������̂ł��B�ŏ��Ƀ��O���A�b�v���[�h���A����<span class="en">Blosxom</span>���N�����ꂽ�ۂɃ��O�t�@�C���ɃA�b�v���[�h�����t�@�C���̏�񂪒ǋL����܂��B�����Ď��񂩂�͂��̏������Ƀ��O��\�����܂��B���O�t�@�C���Ɋ��q�����e���O�ɑ΂������1�i�t�@�C���ւ̃p�X�Ɠ��t�j�ł����A���O�i���L�j�������Ȃ�ƃ��O�t�@�C�����傫���Ȃ��Ă����܂��B</p><p>����ŏC���������O����ɏオ���Ă���S�z�͂Ȃ��Ȃ�܂����B�������A�t�@�C���̓��t���̂�ύX������̂ł͂Ȃ��̂ŁA�t�@�C���̖{���̓��t�̓A�b�v���[�h�������ɂȂ��Ă��܂��B���������āA<span class="en">entries_index</span>�̃��O�t�@�C�����폜����Ƒ�ςȎ��ɂȂ�܂��B</p><h3>�v���O�C���̃p�[�~�b�V����</h3><p>�v���O�C���̃p�[�~�b�V������K�؂ɐݒ肵�Ȃ��ƁA�Ⴆ�΃v���O�C���̕ۑ��ꏊ������ʂ�̖��O�Őݒ肵�����Ȃǂ̓u���E�U�Ńv���O�C���̏ꏊ��<span class="en">URL</span>�ŗ^����΃v���O�C���̒��g���ی����ɂȂ�ꍇ������܂��B�܂��A�O�q��<span class="en">entries_index</span>�̃��O�t�@�C���₻�̑��̃v���O�C���̃e���|�����t�@�C���i���O�t�@�C���j�������ł��B</p><pre class="en">
+<td id="contents"><h1><a name="top" class="bl">訳者が使ってみた感想</a></h1><p><span class="en">Blosxom</span>はプロバイダでも多く提供している <span class="en">Perl</span>が動作すれば使える、と言う容易さが魅力です。人気のある<span class="en">Movable Type</span>等の<span class="en">Blog</span>システムはデータベースサーバを必要としたりと、通常の（日本の）プロバイダでは利用するのが厳しいことがありますが、<span class="en">Blosxom</span>は多くの場合、動作すると思います。</p><h2>インストール</h2><p>インストールは結構簡単です。掲示板スクリプトなど、どこかの配布サイトからもらってきて設置した事があるというのであれば雑作も無いでしょう。<span class="en">Perl</span>で自作アプリケーションを作成しているのであればなおさらです。例えその経験が無くても、スクリプトファイル（<span class="en">blosxom.cgi</span>）をテキストエディタで開いてそれを多少編集する勇気、そしてプロバイダを使う場合にはプロバイダの環境の説明をある程度理解できれば設置できると思います。プロバイダの説明を全く理解できない場合は…少しウェブで調べるか分かる人に聞いてみて下さい。</p><p><span class="en">Blosxom</span>を使うと言うことは恐らく、多くの場合はインターネットに公開することが目的かと思います。それにはプロバイダのスペースを使うことになる場合も多いかと思います。まずはプロバイダでホームページを設置できて、かつ独自の<span class="en">CGI</span>スクリプトを使うことができるかを確認してください。これはプロバイダの利用手引きやホームページに書かれています。ホームページを持てないのであれば諦めるしかありませんが、それが可能で、独自<span class="en">CGI</span>スクリプトを使用できるとなればそのほとんどは<span class="en">Perl</span>が利用できると思いますので<span class="en">Blosxom</span>が動作できる可能性が高くなります。</p><p>プロバイダの説明にしたがって、<span class="en">Perl</span>へのパスを確認します。これは <span class="en">#!/usr/perl/bin/perl</span> みたいなやつです。これを<span class="en">blosxom.cgi</span>の1行目で確認して、違っていれば書き換えます。</p><p>次に、サーバのどのディレクトリ（フォルダ）に<span class="en">blosxom.cgi</span>を置けば良いのか、プロバイダの説明に従ってください。その場所は<span class="en">cgi-bin</span>であったり、貴方のディレクトリのどこでも構わない等、プロバイダによって異なる場合があります。</p>
+<p>独自<span class="en">CGI</span>スクリプトをどこにおけば良いかわかった。でも、ここで問題になるかも知れない事項があります。それは、ログデータを置くディレクトリの絶対パスです。<span class="en">Blosxom</span>の設定で<span class="en">$datadir</span>に設定する重要なものです。絶対パスは例えばこのページの<span class="en">URL</span>のように <span class="en">&quot;/www.yk.rim.or.jp/~hoge/blosxom/&quot;</span>のような形とは多くの場合、異なっています。<span class="en">/home/hoge/public_html/blosxom</span>のようになっているかも知れません（リムネットではこれとはかなり異なるものになっています）。プロバイダの利用手引きやホームページの説明を良く読んでください。これを<span class="en">$datadir</span>に適切に設定できないと、<span class="en">Blosxom</span>はログの場所を見つけることができません。</p>
+<p>ディレクトリ（フォルダ）に<span class="en">blosxom.cgi</span>を置いたら、<span class="en">$datadir</span>で指定したログ保管ディレクトリをその下に作成し、<span class="en">blosxom.cgi</span>のパーミッションを確認してください。パーミッションは<span class="en">blosxom.cgi</span>を誰が実行させるかを指定するものです。プロバイダによって異なります。私のリムネットでは<span class="en">700</span>になっていますが、プロバイダによっては<span class="en">777</span>であったりするかもしれません。これもプロバイダの説明を読んでください。</p><p><span class="en">Blosxom</span>を使ったウェブログを表示しようとして<span class="en">&quot;Internal Server Error&quot;</span>（エラーに関するもの）と表示された場合は、設定が間違っている可能性があります。設定が間違っていなくてもプロバイダによってはエラーになる場合もありますので、その場合はプロバイダに問い合わせてみてください。</p><div class="figure"><img src="image/directory.gif" width="260" height="400" alt="ディレクトリ階層"></div><h2>ログ</h2><p><span class="en">Blosxom</span>単体ではログを作成、編集、削除と言った機能は提供していません。<a href="plugin_registry.html" class="en">wikiedish</a>のようなプラグインを用いるとブラウザでそれらを行うことができるみたいですが、基本はテキストエディタを使います。<span class="en">Mac</span>や<span class="en">Windows</span>、<span class="en">Unix</span>系標準のテキストエディタを使ったり、その他のサードパーティ製のテキストエディタを使います（文字のエンコードを変える場合はそれに対応しているテキストエディタを使ってください）。テキストエディタでログを作成したら、<span class="en">FTP</span>クライアントソフト等を使ってサーバにアップロードすると、<span class="en">Blosxom</span>はそれを勝手に見つけて表示してくれます。削除はそのファイルを削除することです。</p><p>ログの作成には1つ、決まりがあります。最初の1行がタイトル（題名）になると言うことです。2行目から最後までは本文になります。うっかり1行目から本文を始めてしまうと、ブラウザで見たときに非常に長いタイトルとなって表示されてしまいます。</p><h2>フレーバー</h2><p><span class="en">Blosxom</span>ではフレーバー（<span class="en">Flavour</span>）と呼ばれるものを使ってページの&quot;見た目&quot;を変更します。</p><p>
+フレーバーとは他のシステムではテンプレートやテーマ等と呼ばれているもので、ページの見た目を決めるものです。<span class="en">Blosxom</span>公式サイトの説明文では&quot;匂い&quot;や&quot;庭&quot;など、本来の花である&quot;ブロッサム&quot;になぞらえて表現している部分もあります。まさに貴方のページの&quot;香り（見た目）&quot;をあらわすものが&quot;フレーバー&quot;です。<span class="en">Blosxom</span>では貴方独自のフレーバーを作成することも、しかもそれを何種類も用意してページによって使い分けると言うことも可能です。</p><p><span class="en">Blosxom</span>のデフォルトのフレーバーは<span class="en">Blosxom</span>自体（<span class="en">blosxom.cgi</span>）に書かれています。<span class="en">Blosxom</span>をインストールして初めて表示される見た目がこれです。<span class="en">Blosxom</span>はこのフレーバーに従ってブラウザに表示される見た目を決定しています（ブラウザにデータを送ります）。しかし、<span class="en">blosxom.cgi</span>に書かれたフレーバーを変更するのは大変ですし、<span class="en">Blosxom</span>は外部ファイルをフレーバーとして指定できるので特別な理由が無い限りは無駄な作業です。まずは<a href="http://www.blosxom.com/"><span class="en">Blosxom</span>公式サイト</a>の<span class="en">Flavour Sampler</span>をダウンロードして、そのファイルの内容を確認してみることをお勧めします（<span class="en">Blosxom</span>のアーカイブにはフレーバーファイルは含まれていません。<span class="en">Mac</span>のインストーラ版では含まれているみたいですが）。フレーバーファイルは<span class="en">$datadir</span>に置きます。そしてフレーバーファイルの拡張子を<span class="en">blosxom.cgi</span>の設定で指定します。指定するフレーバーとは、フレーバーファイルの拡張子です。フレーバーファイルの拡張子がフレーバーの名前になります。そうすると、そのフレーバーで表示するようになります。<span class="en">URL</span>に指定して変更する方法もあります。それについてはメインの説明を読んでください。</p><p>フレーバーファイルも単なるテキストファイルです。中身は<span class="en">HTML</span>とフレーバーコンポーネントと言うもので構成されています。それをテキストエディタで編集したり、他にも拡張子（拡張子はフレーバーの名前になります）を変えたものを用意することでページによって見た目を変えることもできます。フレーバーファイルは5種類で1セットとなっており、中身の基本は<span class="en">HTML</span>ですが、それら一つ一つが<span class="en">HTML</span>として完結しているわけではありません（常に<span class="en">&lt;/html&gt;</span>で終わっているわけではありません）。<span class="en">Blosxom</span>はこの5種類のファイルを繋ぎ合わせて最終的にブラウザで見られるようにします。したがって、例えばホームページ作成ソフトでフレーバーを作成するには、できた<span class="en">HTML</span>ファイルを切り貼りする必要があります。また、必要に応じて適切なフレーバーコンポーネントを埋め込みます。私の日記を例に挙げるとフレーバーはページのレイアウトに関して以下のような構成になっています（<span class="en">flav</span>はフレーバー名です）。</p><div class="figure"><img src="image/flavour.gif" width="410" height="280" alt="フレーバーの構成"></div><p>作り方によっては全てのフレーバーファイルを用意するのは面倒かもしれませんが（フッタはいらない等）、<span class="en">Blosxom</span>では上記の5種類のフレーバーファイルを必要としますので、削除してはいけません。</p><p>フレーバーコンポーネントは$で始まるもので（<span class="en">$yr</span>、<span class="en">$title</span>等）、<span class="en">Blosxom</span>の設定や、日付、ログの内容、プラグイン等によってフレーバーに自動的に取り込まれるものです。つまり、<span class="en">$</span>で始まる文字は、ページとして表示されるときに変換されます。例えば、<span class="en">story.flav</span>の中に<span class="en">$title</span>とあれば、<span class="en">$title</span>はそのログのタイトル（ログファイルの1行目がタイトル（題名）になる）に置き換わって表示されます。</p><p><span class="en">head</span>フレーバーはページの最初の書式を指定するものなので、<span class="en">&lt;html&gt;</span>などを含むことになります。逆に<span class="en">foot</span>フレーバーはページの最後の書式を指定するので<span class="en">&lt;/html&gt;</span>で終わる事になります。</p><p><span class="en">content_type</span>フレーバーは<span class="en">head</span>フレーバーに<span class="en">content=&quot;text/html; charset=Shift_JIS&quot;</span>等と指定してしまえば用を成しませんが、ページによって<span class="en">XML</span>だったりする場合は<span class="en">content_type</span>フレーバーを適宜切り替えます。<span class="en">story</span>フレーバーと<span class="en">date</span>フレーバーは他のフレーバーとは多少、性質が異なります。他のフレーバーはページの表示に一度だけ使われますが、<span class="en">story</span>フレーバーと<span class="en">date</span>フレーバーはログを表示するために反復的に使用されます。つまり、<span class="en">story</span>フレーバーや<span class="en">date</span>フレーバーで指定した書式は、ログがブラウザで表示される際に、全てのログと日付に適用されますので、リンクをクリックしてページを切り替えて別のフレーバーを適用する、など以外の場合は標準では例えば「特に強調したいログの見た目だけ変える」と言うようなことはできません（そもそも必要ないかもしれませんが）。</p><p><span class="en">content_type</span>フレーバーはどちらかと言うと特殊ですが、ページの見た目を考えた場合、<span class="en">head</span>フレーバー、<span class="en">date</span>フレーバー、<span class="en">story</span>フレーバー、<span class="en">foot</span>フレーバーの順に繋ぎ合せて行って、<span class="en">HTML</span>として成立していることが条件になります（<span class="en">$</span>で始まるコンポーネントは置き換わります）。</p><h2>プラグイン</h2><p><span class="en">Blosxom</span>単体（<span class="en">blosxom.cgi</span>）ではログへのコメントやカレンダーと言った機能は提供していません。ログを日付順に表示する程度です。しかし、カレンダーやコメント、トラックバックと言った機能は&quot;プラグイン&quot;によって後から追加することができます。私の日記ではカレンダー、カテゴリ、<span class="en">entries_index</span>、その他を使っています。</p>
+<p>プラグインによっては<span class="en">Perl</span>のバージョンやモジュールに依存することがあるかもしれませんが、<span class="en">Rael</span>さんは「特別な条件を必要とするプラグインは作らないで欲しい」と言っていますし、プラグインの作成者もそれを意識していると思います。ですので、もし、すぐに動かなくてもちょっとした修正をすれば動くことも多くあると思いますし、対処の仕方はプラグインファイルの中や作者のサイトに書かれていると思います。</p><h2>カテゴリ</h2><p>パソコンで<span class="en">Microsoft Word</span>等を使って文書を作成している場合、<span class="en">Windows</span>であれば良く、&quot;マイドキュメント&quot;に文書を保存するでしょう。場合によってはマイドキュメントに新たにフォルダを作ってそこにしまうこともあるでしょう。<span class="en">Blosxom</span>でのログ作成はそれに似ています。<span class="en">Blosxom</span>の設定で<span class="en">$datadir</span>に指定した場所を<span class="en">Windows</span>の&quot;マイドキュメント&quot;のような場所と考えれば、<span class="en">$datadir</span>の中に新たにフォルダ（ディレクトリ）を作ってログを保存すると言うのは、先ほどのパソコンでの文書保存に似ています。<span class="en">Blosxom</span>では<span class="en">$datadir</span>に作成したフォルダ（ディレクトリ）は&quot;カテゴリ&quot;として扱われます。そのため、ログの内容に応じてフォルダ（ディレクトリ）を作成すればログをカテゴリごとに整理できます。カテゴリは<span class="en">Blosxom</span>の標準のフレーバーでは本文の下に表示されます。</p><h2>その他</h2><h3>ログの日付</h3><p>ログを書いて<span class="en">FTP</span>でアップロードすれば表示されると言う簡単さがありますが、私が使ってみて困ったことがあります。それは過去のログを書き直してアップロードすると、アップロードした時点の日付や時間でそのログが表示されてしまうことです。つまり、一番上に表示されてしまうことです。</p><p>新しく修正、または加筆したと言う意味ではそれを見てくれる人に知らせる意味では良いかもしれません。しかし私の場合はそうしたくなかったので、どうすれば良いかと考えました。そして、シェルを利用するスクリプトをアップロードしてそれをブラウザで呼び出すと日付を変更すると言うものを最初利用しましたが、私のスキルではファイル一つ一つに対してスクリプト内を変更しなくてはならなかったので、たまにログを変更した場合には事足りましたが、誤って多くのログを上書きしてしまった時にはほとんど絶望的に思えました。</p><p>そこで<span class="en">entries_index</span>プラグインを導入しました。これは、ログの日付をログファイルとして保存しておいて、ログを修正してもそのログファイルに書かれた日付として表示してくれるものです。最初にログをアップロードし、次に<span class="en">Blosxom</span>が起動された際にログファイルにアップロードしたファイルの情報が追記されます。そして次回からはその情報を元にログを表示します。ログファイルに既述される各ログに対する情報は1つ（ファイルへのパスと日付）ですが、ログ（日記）が多くなるとログファイルも大きくなっていきます。</p><p>これで修正したログが上に上がってくる心配はなくなりました。ただし、ファイルの日付自体を変更するものではないので、ファイルの本当の日付はアップロードした時になっています。したがって、<span class="en">entries_index</span>のログファイルを削除すると大変な事になります。</p><h3>プラグインのパーミッション</h3><p>プラグインのパーミッションを適切に設定しないと、例えばプラグインの保存場所を説明通りの名前で設定した時などはブラウザでプラグインの場所を<span class="en">URL</span>で与えればプラグインの中身が丸見えになる場合があります。また、前述の<span class="en">entries_index</span>のログファイルやその他のプラグインのテンポラリファイル（ログファイル）もそうです。</p><pre class="en">
 http://****/blog/plugins/entries_index
 http://****/blog/plugins/state/.entries_index.index
-</pre><p class="bl">****�̓z�X�g����</p><p>�v���O�C���⃍�O�t�@�C���ɂ̓p�X�Ȃǂ̏�񂪊܂܂�Ă���ꍇ������A����������Əd�v�Ȃ��̂����݂��邩������܂���B�p�[�~�b�V������K�؂ɐݒ肷�邱�ƂŃA�N�Z�X�ł��Ȃ��悤�ɂ��邱�Ƃ��ł��܂��B���̃v���o�C�_�ł�<span class="en">600</span>�ł��B</p>
-<p></p><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</pre><p class="bl">****はホスト名等</p><p>プラグインやログファイルにはパスなどの情報が含まれている場合があり、もしかすると重要なものが存在するかもしれません。パーミッションを適切に設定することでアクセスできないようにすることができます。私のプロバイダでは<span class="en">600</span>です。</p>
+<p></p><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/myinstall.html
+++ b/myinstall.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/plugin_registry.html
+++ b/plugin_registry.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<meta charset="UTF-8">
 <meta name="keywords" content="blosxom,日本語,翻訳">
 <title>blosxomサイトの日本語訳::プラグイン登録ページ</title>
 

--- a/plugin_registry.html
+++ b/plugin_registry.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">

--- a/plugin_registry.html
+++ b/plugin_registry.html
@@ -2,8 +2,8 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="keywords" content="blosxom,���{��,�|��">
-<title>blosxom�T�C�g�̓��{���::�v���O�C���o�^�y�[�W</title>
+<meta name="keywords" content="blosxom,日本語,翻訳">
+<title>blosxomサイトの日本語訳::プラグイン登録ページ</title>
 
 <LINK REV="MADE" HREF=" "> 
 <LINK rel="INDEX" href="index.html">
@@ -11,226 +11,226 @@
 </head>
 
 <body>
-<div id="header"><span class="en">blosxom</span>::���{���</div>
-<table id="frame" cellspacing="0" cellpadding="0" summary="�t���[��">
+<div id="header"><span class="en">blosxom</span>::日本語訳</div>
+<table id="frame" cellspacing="0" cellpadding="0" summary="フレーム">
 <tbody>
 <tr>
 <td id="menu">
-<h4>�|��ɂ���</h4>
+<h4>翻訳について</h4>
 <ul class="mid">
-<li><a href="index.html" title="���ǂ݂�������">���ǂ݂�������</a></li>
+<li><a href="index.html" title="お読みください">お読みください</a></li>
 </ul>
 <h4 class="en">blosxom</h4>
 <ul class="mid">
-<li><a href="about.html" title="Blosxom�ɂ���"><span class="en">Blosxom</span>�ɂ���</a></li>
-<li><a href="features.html" title="Blosxom�̋@�\">�@�\</a></li>
-<li><a href="colophon.html" title="���t">���t</a></li>
-<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="�j���[�X">�j���[�X�i�p��j</a></li>
-<li><a href="http://groups.yahoo.com/group/blosxom/" title="���[�����O���X�g">���[�����O���X�g�i�p��j</a></li>
-<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="��">�񑡁i�p��j</a></li>
+<li><a href="about.html" title="Blosxomについて"><span class="en">Blosxom</span>について</a></li>
+<li><a href="features.html" title="Blosxomの機能">機能</a></li>
+<li><a href="colophon.html" title="奥付">奥付</a></li>
+<li><a href="http://www.raelity.org/archives/computers/internet/weblogs/blosxom/" title="ニュース">ニュース（英語）</a></li>
+<li><a href="http://groups.yahoo.com/group/blosxom/" title="メーリングリスト">メーリングリスト（英語）</a></li>
+<li><a href="http://s1.amazon.com/exec/varzea/pay/T3ENE5Z31EQZ0O" title="寄贈">寄贈（英語）</a></li>
 </ul>
-<h4>���[�U�����h�L�������g</h4>
+<h4>ユーザ向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_users_overview.html" title="Blosxom�̊T�v">�T�v</a></li>
-<li><a href="doc_users_install_dynamic.html" title="Blosxom�̃C���X�g�[��">�C���X�g�[��</a></li>
-<li><a href="doc_users_configure.html" title="Blosxom�̐ݒ�">���ݒ�</a></li>
-<li><a href="doc_users_blog.html" title="�E�F�u���O">�E�F�u���O</a></li>
-<li><a href="doc_users_view.html" title="�E�F�u���O�̉{��">�{��</a></li>
-<li><a href="doc_users_flavour.html" title="�t���[�o�[">�t���[�o�[</a></li>
-<li><a href="doc_users_syndicate.html" title="�V���W�P�[�g">�V���W�P�[�g</a></li>
-<li><a href="doc_users_plugins.html" title="�v���O�C��">�v���O�C��</a></li>
-<li><a href="plugin_registry.html" title="�v���O�C���o�^�y�[�W">�v���O�C���o�^�y�[�W</a></li>
-<li><a href="doc_users_configure_static.html" title="�ÓI�\���̐ݒ�">�ÓI�\���̐ݒ�</a></li>
-<li><a href="faq.html" title="�ǂ����鎿��"><span class="en">faq</span></a></li>
-<li>�g�p��*</li>
+<li><a href="doc_users_overview.html" title="Blosxomの概要">概要</a></li>
+<li><a href="doc_users_install_dynamic.html" title="Blosxomのインストール">インストール</a></li>
+<li><a href="doc_users_configure.html" title="Blosxomの設定">環境設定</a></li>
+<li><a href="doc_users_blog.html" title="ウェブログ">ウェブログ</a></li>
+<li><a href="doc_users_view.html" title="ウェブログの閲覧">閲覧</a></li>
+<li><a href="doc_users_flavour.html" title="フレーバー">フレーバー</a></li>
+<li><a href="doc_users_syndicate.html" title="シンジケート">シンジケート</a></li>
+<li><a href="doc_users_plugins.html" title="プラグイン">プラグイン</a></li>
+<li><a href="plugin_registry.html" title="プラグイン登録ページ">プラグイン登録ページ</a></li>
+<li><a href="doc_users_configure_static.html" title="静的表示の設定">静的表示の設定</a></li>
+<li><a href="faq.html" title="良くある質問"><span class="en">faq</span></a></li>
+<li>使用例*</li>
 </ul>
-<h4>�J���Ҍ����h�L�������g</h4>
+<h4>開発者向けドキュメント</h4>
 <ul class="mid">
-<li><a href="doc_dev_overview.html" title="�T�v�F�J���Ҍ���">�T�v</a></li>
-<li><a href="doc_dev_plugins.html" title="�v���O�C���F�J���Ҍ���">�v���O�C��</a></li>
-<li><a href="doc_dev_plugin_register.html" title="�J���Ҍ����F�v���O�C���o�^">�v���O�C���̓o�^</a></li>
+<li><a href="doc_dev_overview.html" title="概要：開発者向け">概要</a></li>
+<li><a href="doc_dev_plugins.html" title="プラグイン：開発者向け">プラグイン</a></li>
+<li><a href="doc_dev_plugin_register.html" title="開発者向け：プラグイン登録">プラグインの登録</a></li>
 </ul>
-<h4>�_�E�����[�h</h4>
+<h4>ダウンロード</h4>
 <ul class="mid">
 <li><a href="downloads.html#macosx" title="Macintosh"><span class="en">mac</span></a></li>
 <li><span class="en">windows</span>*</li>
-<li><a href="downloads.html" title="�S�Ă̐l��">�S�Ă̐l��</a></li>
-<li><a href="license.html" title="���C�Z���X">���C�Z���X</a></li>
-<li>��������*</li>
+<li><a href="downloads.html" title="全ての人へ">全ての人へ</a></li>
+<li><a href="license.html" title="ライセンス">ライセンス</a></li>
+<li>共同制作*</li>
 </ul>
-<p>*�����T�C�g�Ŗ����M</p>
+<p>*公式サイトで未執筆</p>
 </td>
-<td id="contents"><h1><a name="top" class="bl">�v���O�C���o�^�y�[�W</a></h1><p><span class="en">Blosxom</span>�̓v���O�C���A�[�L�e�N�`���ɂ���Ė����Ɋg�����鎖���ł��܂��B�����ł͔��W�A�g���A�����A��тȂǂɊւ���f���炵���v���O�C����������ł��傤�B�����Ă����͋M���̂悤��<span class="en">Blosxom</span>���[�U�����������̂Ȃ̂ł��I</p><p> �R�~���j�e�B�Ƌ��L�ł���v���O�C�����������ł����H�@<a href="doc_dev_plugin_register.html">�����Ńv���O�������Ă��������I</a></p><h2 class="en">/plugins/archives</h2><dl> 
+<td id="contents"><h1><a name="top" class="bl">プラグイン登録ページ</a></h1><p><span class="en">Blosxom</span>はプラグインアーキテクチャによって無限に拡張する事ができます。ここでは発展、拡張、統合、喜びなどに関する素晴らしいプラグインが見つかるでしょう。そしてそれらは貴方のような<span class="en">Blosxom</span>ユーザが書いたものなのです！</p><p> コミュニティと共有できるプラグインをお持ちですか？　<a href="doc_dev_plugin_register.html">ここでプラグを差してください！</a></p><h2 class="en">/plugins/archives</h2><dl> 
 <dt class="en">archives</dt>
 <dd> 
-<p><span class="en">$archives::archives</span>��N�ƌ��̃c���[�A�����Ċe�L���̐��Œu�������܂��B</p>
+<p><span class="en">$archives::archives</span>を年と月のツリー、そして各記事の数で置き換えます。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/authentication</h2><dl> 
 <dt class="en">login</dt>
 <dd> 
-<p>�T�C�g�̓���̕����ɃA�N�Z�X���邽�߂̃��[�U���ƃp�X���[�h��ݒ�ł���悤�ɂ��܂��B</p>
+<p>サイトの特定の部分にアクセスするためのユーザ名とパスワードを設定できるようにします。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/author</h2><dl> 
 <dt class="en">author</dt>
 <dd> 
-<p>&quot;<span class="en">meta-author:</span>&quot;�^�O�𗘗p�\�ɂ��A�e�L���̒��҂�ݒ�ł���悤�ɂ��܂��B<span class="en">info</span>�^�O�Ŏg����f�t�H���g�̒��҂��ݒ�ł��܂��B�����ŏ���<span class="en">Perl</span>�ŏ������Ƃ������̂ł�...</p>
+<p>&quot;<span class="en">meta-author:</span>&quot;タグを利用可能にし、各記事の著者を設定できるようにします。<span class="en">info</span>タグで使われるデフォルトの著者も設定できます。私が最初に<span class="en">Perl</span>で書こうとしたものです...</p>
 </dd>
 <dt class="en">fauxami</dt>
 <dd> 
-<p>�S�Ă̂��Ƃ̑O�ɓ���̋�؂�i�W���ł�.�i�h�b�g�j�j���g���ăE�F�u���O���|�X�g�����l��&quot;���O&quot;��񋟂��܂��B���̂��߁A<span class="en">jack.story1.txt</span>��<span class="en">jack</span>��<span class="en">$fauxami::name</span>�ɂȂ�A<span class="en">jill.story2.txt</span>��<span class="en">jill</span>��<span class="en">$fauxami::name</span>�ɂȂ�܂��B</p>
+<p>全てのことの前に特定の区切り（標準では.（ドット））を使ってウェブログをポストした人の&quot;名前&quot;を提供します。そのため、<span class="en">jack.story1.txt</span>は<span class="en">jack</span>の<span class="en">$fauxami::name</span>になり、<span class="en">jill.story2.txt</span>は<span class="en">jill</span>の<span class="en">$fauxami::name</span>になります。</p>
 </dd>
 <dt class="en">whoami</dt>
 <dd> 
-<p>�e�b��ɑ΂��ă��[�U���ƃt���l�[����񋟂��܂��B�O���[�v�ŃE�F�u���O���쐬����̂ɕ֗��ł��B</p>
+<p>各話題に対してユーザ名とフルネームを提供します。グループでウェブログを作成するのに便利です。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/browser</h2><dl> 
 <dt class="en">clicktrack</dt>
 <dd> 
-<p>302���_�C���N�g�ɂ��<span class="en">URL</span>���L���ɏ������ނ̂ŁA�E�F�u���O�̃N���b�N�����M���O���鎖���ł��܂��B</p>
+<p>302リダイレクトによる<span class="en">URL</span>を記事に書き込むので、ウェブログのクリックをロギングする事ができます。</p>
 </dd>
 <dt class="en">uainclude</dt>
 <dd> 
-<p>���[�U�̃u���E�U��<span class="en">User-Agent</span>�Ɋ�Â��ăy�[�W��<span class="en">&lt;head&gt;</span>�Z�N�V�����ɓ���̃R���e���c��ǂݍ��݂܂��B</p>
+<p>ユーザのブラウザの<span class="en">User-Agent</span>に基づいてページの<span class="en">&lt;head&gt;</span>セクションに特定のコンテンツを読み込みます。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/calendar</h2><dl> 
 <dt class="en">calendar</dt>
 <dd> 
-<p>�A�[�J�C�u���ꂽ�L���փ����N���ꂽ���t�����N���V�b�N�ȃE�F�u���O�J�����_�[���쐬���܂��B</p>
+<p>アーカイブされた記事へリンクされた日付を持つクラシックなウェブログカレンダーを作成します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/category</h2><dl> 
 <dt class="en">categories</dt>
 <dd> 
-<p>�E�F�u���O�Ɋւ���p�X�ƃJ�e�S���̃c���[�\�����s���܂��B</p>
+<p>ウェブログに関するパスとカテゴリのツリー表示を行います。</p>
 </dd>
 <dt class="en">categorylist</dt>
 <dd> 
-<p>���j���[�T�C�h�o�[�ɑ΂���J�e�S�����j���[��񋟂��܂��B</p>
+<p>メニューサイドバーに対するカテゴリメニューを提供します。</p>
 </dd>
 <dt class="en">fixcategory</dt>
 <dd> 
-<p><span class="en">URL</span>�ōŏ��̃��x���̃J�e�S����u�������܂��B�E�F�u���O���W���Ǘ�����̂��A����<span class="en">followsymlink</span>�v���O�C����p���Ă���ƕ֗��ł��B</p>
+<p><span class="en">URL</span>で最初のレベルのカテゴリを置き換えます。ウェブログを集中管理するのが、特に<span class="en">followsymlink</span>プラグインを用いていると便利です。</p>
 </dd>
 <dt class="en">followsymlinks</dt>
 <dd>
-<p>�V���{���b�N�����N���J�e�S���Ƃ��Ĉ����܂��B</p>
+<p>シンボリックリンクをカテゴリとして扱います。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/date</h2><dl>
 <dt class="en">date_fullname</dt>
 <dd> 
-<p>�ړI�F<span class="en">$date_fullname::dw</span> (�T�̓��j��<span class="en">$date_fullname::mo</span> (���̖��O)���e�X���S�ȓ��ƌ��̖��O�ɂ��܂��B</p>
+<p>目的：<span class="en">$date_fullname::dw</span> (週の日）と<span class="en">$date_fullname::mo</span> (月の名前)を各々完全な日と月の名前にします。</p>
 </dd>
 <dt class="en">date_translate</dt>
 <dd> 
-<p>�T�̐l���̖��O���M���̑I����������ɕϊ����܂��B</p>
+<p>週の人月の名前を貴方の選択した言語に変換します。</p>
 </dd>
 <dt class="en">timestamp</dt>
 <dd> 
-<p>�t�H�[�}�b�g�\�ȕ�����A�܂��̓����E�X��Ŋe�L���ɑ΂��ă^�C���X�^���v���쐬���܂��B�\�ł����<span class="en">entries_index</span>����L���b�V�����g�����Ƃ��ł��܂��B</p>
+<p>フォーマット可能な文字列、またはユリウス暦で各記事に対してタイムスタンプを作成します。可能であれば<span class="en">entries_index</span>からキャッシュを使うことができます。</p>
 </dd>
 <dt class="en">timezone</dt>
 <dd>
-<p><span class="en">Blosxom</span>�̃^�C���X�^���v�����̃^�C���]�[���ŕ\�����܂��B</p>
+<p><span class="en">Blosxom</span>のタイムスタンプを特定のタイムゾーンで表示します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/debug</h2><dl>
 <dt class="en">seeerror</dt>
 <dd> 
-<p>�G���[���O�����邱�Ƃ��ł��Ȃ��ꍇ�Ƀu���E�U�ŉ{���ł���G���[���O���쐬���܂��B</p>
+<p>エラーログを見ることができない場合にブラウザで閲覧できるエラーログを作成します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/display</h2><dl>
 <dt class="en">SmartyPants</dt>
 <dd>
-<p>����̕����̕ϊ����s���܂��B--�@�N�I�[�g�A�_�b�V���A�ȉ~�B</p>
+<p>幾つかの文字の変換を行います。--　クオート、ダッシュ、楕円。</p>
 </dd>
 <dt class="en">allconsuming</dt>
 <dd>
-<p><span class="en">AllConsuming (allconsuming.net)</span>���[�U��<span class="en">reading/purchased/finished/etc</span> �u�b�N�̃��X�g���ȒP�ɋ��L�ł���悤�ɂ��܂��B</p>
+<p><span class="en">AllConsuming (allconsuming.net)</span>ユーザが<span class="en">reading/purchased/finished/etc</span> ブックのリストを簡単に共有できるようにします。</p>
 </dd>
 <dt class="en">antispam</dt>
 <dd>
-<p><span class="en">AntiSpam</span>�̓��[���A�h���X�����W���郍�{�b�g���~�������Ă�������邽�߂ɘb��̒��̃��[���A�h���X���}�X�N���܂��B</p>
+<p><span class="en">AntiSpam</span>はメールアドレスを収集するロボットが掻っ攫っていき難くするために話題の中のメールアドレスをマスクします。</p>
 </dd>
 <dt class="en">better_title</dt>
 <dd>
-<p>�E�F�u���O�̃^�C�g���ɃJ�e�S���ւ̃p�X����ɂ��i���A���A�N�j���܂߂܂��B</p>
+<p>ウェブログのタイトルにカテゴリへのパスや日にち（日、月、年）を含めます。</p>
 </dd>
 <dt class="en">binary</dt>
 <dd>
-<p>�t�@�C���V�X�e���Ŏ��ۂɑ��݂���<span class="en">URL</span>���v�����ꂽ�ꍇ��<span class="en">Blosxom</span>���������������悤�ɂ��A�t�@�C����Ԃ��A�o�C�i���t�@�C���̒񋟂����ăX�N���v�g���I������悤�ɂ��܂��B�t�@�C�������݂��Ȃ��Ƃ��́A<span class="en">Blosxom</span>�̓f�[�^�t�@�C���Ńt���[�o�[�̕ϊ�������K�v�����邪�ǂ����𒲂ׂ܂��B���̃v���O�C���֗̕��ȂƂ���́A�摜��E�F�u���O�Ɋւ��鉽������荞�񂾂肷��Ƃ��ŁA�����f�B���N�g���Ƀt�@�C����u�������ł��܂��B������<span class="en">$url$path</span>���g���ĎQ�Ƃ��܂��B</p>
+<p>ファイルシステムで実際に存在する<span class="en">URL</span>が要求された場合に<span class="en">Blosxom</span>がそれを検索するようにし、ファイルを返し、バイナリファイルの提供をしてスクリプトが終了するようにします。ファイルが存在しないときは、<span class="en">Blosxom</span>はデータファイルでフレーバーの変換をする必要があるがどうかを調べます。このプラグインの便利なところは、画像やウェブログに関する何かを取り込んだりするときで、同じディレクトリにファイルを置く事ができます。それらは<span class="en">$url$path</span>を使って参照します。</p>
 </dd>
 <dt class="en">blogroll</dt>
 <dd>
-<p><span class="en">OPML</span>�t�@�C���̃u���O���[�����\�z���܂��B</p>
+<p><span class="en">OPML</span>ファイルのブログロールを構築します。</p>
 </dd>
 <dt class="en">blox</dt>
 <dd>
-<p>���[�U���I������&quot;<span class="en">paragraph</span>&quot;�^�O���t�@�C���ɒǉ����܂��B<span class="en">&lt;p&gt;</span>�^�O���g���̂���߂܂��傤�I�@���ɂ���^�O�͂��̂܂܂ɂ���܂��B</p>
+<p>ユーザが選択した&quot;<span class="en">paragraph</span>&quot;タグをファイルに追加します。<span class="en">&lt;p&gt;</span>タグを使うのをやめましょう！　既にあるタグはそのままにされます。</p>
 </dd>
 <dt class="en">breadcrumbs</dt>
 <dd>
-<p>�E�F�u���O�̃p�X���Ɍ��݂̈ʒu�ɃN���b�N�ł��鑫�Ղ��쐬���܂��B</p>
+<p>ウェブログのパス内に現在の位置にクリックできる足跡を作成します。</p>
 </dd>
 <dt class="en">chrono</dt>
 <dd>
-<p>���̒P���ȃv���O�C����<span class="en">blosxom.cgi</span>���̃O���[�o���ɒ�`���ꂽ<span class="en">$blosxom:chrono</span>�ϐ��A�܂��͐ݒ�t�@�C���Ɋ�Â��Ęb�����t���i�Â����̂���j�Ƀ��X�g�A�b�v���邽�߂�<span class="en">sort()</span>�֐����Ē�`���܂��B</p>
+<p>この単純なプラグインは<span class="en">blosxom.cgi</span>内のグローバルに定義された<span class="en">$blosxom:chrono</span>変数、または設定ファイルに基づいて話題を日付順（古いものが先）にリストアップするために<span class="en">sort()</span>関数を再定義します。</p>
 </dd>
 <dt class="en">directorybrowse</dt>
 <dd>
-<p>�����p�X�������ꂼ��̃����N�ɕϊ����܂��B�Ⴆ�� <span class="en">/one/two/three</span>�̓o�j���u���b�T���̈�̃����N�ł����A���̃v���O�C�����g���ƁA<span class="en">one</span>�A<span class="en">two</span>�A<span class="en">three</span>���e�X�̃����N�ɂȂ�܂��B</p>
+<p>長いパス名をそれぞれのリンクに変換します。例えば <span class="en">/one/two/three</span>はバニラブロッサムの一つのリンクですが、このプラグインを使うと、<span class="en">one</span>、<span class="en">two</span>、<span class="en">three</span>が各々のリンクになります。</p>
 </dd>
 <dt class="en">flavourmenu</dt>
 <dd>
-<p>���[�U�����݂̃y�[�W���قȂ�t���[�o�[�ŉ{��������A�S�ẴE�F�u���O���قȂ�t���[�o�[�ŉ{��������ł���悤�Ƀ��j���[���쐬���܂��B</p>
+<p>ユーザが現在のページを異なるフレーバーで閲覧したり、全てのウェブログを異なるフレーバーで閲覧したりできるようにメニューを作成します。</p>
 </dd>
 <dt class="en">fortune</dt>
 <dd>
-<p><span class="en">Unix</span>�}�V���ɂ���悤�Ȑ肢�v���O�����̌��ʂ��o�͂��܂��B�t���[�o�[�e���v���[�g�Ŏg�����Ƃ��ł��܂��B</p>
+<p><span class="en">Unix</span>マシンにあるような占いプログラムの結果を出力します。フレーバーテンプレートで使うことができます。</p>
 </dd>
 <dt class="en">gallery</dt>
 <dd>
-<p>�X���C�h����<span class="en">TrueType</span>�̐����������T���l�[���M�������[�𐶐����܂��B<span class="en">Image::Magick</span>���K�v�ł��B���݂͐ÓI���[�h�݂̂ł��B</p>
+<p>スライド式の<span class="en">TrueType</span>の説明がついたサムネールギャラリーを生成します。<span class="en">Image::Magick</span>が必要です。現在は静的モードのみです。</p>
 </dd>
 <dt class="en">hotlists</dt>
 <dd>
-<p>����̃J�e�S�����ɍŐV�̋L���̃��X�g���쐬���܂��B</p>
+<p>特定のカテゴリ内に最新の記事のリストを作成します。</p>
 </dd>
 <dt class="en">icons</dt>
 <dd>
-<p><span class="en">Slashdot</span>���̃A�C�R����񋟂��܂��B</p>
+<p><span class="en">Slashdot</span>風のアイコンを提供します。</p>
 </dd>
 <dt class="en">lastvisited</dt>
 <dd>
-<p><span class="en">cookie</span>�v���O�C����<span class="en">lastmodified</span>�v���O�C���ƈꏏ�Ɏg�����ƂŁA�܂����Ă��Ȃ��e�b��̃^�C�g����<span class="en">'new stuff!</span>'��ǉ����܂��B����̓J�X�^�}�C�Y�ł��܂��i�W���ł�'<span class="en">NEW!</span>'</p>
+<p><span class="en">cookie</span>プラグインと<span class="en">lastmodified</span>プラグインと一緒に使うことで、まだ見ていない各話題のタイトルに<span class="en">'new stuff!</span>'を追加します。これはカスタマイズできます（標準では'<span class="en">NEW!</span>'</p>
 </dd>
 <dt class="en">menu</dt>
 <dd>
-<p>���݂̃y�[�W����H���T�u�f�B���N�g���̃��X�g��\�����郁�j���[�ŁA<span class="en">Menu displays a listing of the subdirectories 
+<p>現在のページから辿れるサブディレクトリのリストを表示するメニューで、<span class="en">Menu displays a listing of the subdirectories 
 available from your current page, showing only those paths that lead to available 
 articles and abiding by the settings of the exclude plugin, if installed.</span> </p>
 </dd>
 <dt class="en">netflix</dt>
 <dd>
-<p>�M����<span class="en">netflix</span>�L���[�R���e���c�܂��͋M�����`�F�b�N�������[�r�[���X�g�����L���܂��B</p>
+<p>貴方の<span class="en">netflix</span>キューコンテンツまたは貴方がチェックしたムービーリストを共有します。</p>
 </dd>
 <dt class="en">now_playing</dt>
 <dd>
-<p>���̃v���O�C����<span class="en">TrackBack</span>�v���O�C�����g����<span class="en">$now::playing:::last</span>�ɍŋ�<span class="en">Winamp</span>�ōĐ��������Ȃ��֘A�t�����܂��B�����<span class="en">Benn 
-Trott</span>��<span class="en">tb.cgi</span>��<span class="en">DoSomething Winamp</span>�v���O�C�����g���܂��B</p>
+<p>このプラグインは<span class="en">TrackBack</span>プラグインを使って<span class="en">$now::playing:::last</span>に最近<span class="en">Winamp</span>で再生した数曲を関連付けします。これは<span class="en">Benn 
+Trott</span>の<span class="en">tb.cgi</span>と<span class="en">DoSomething Winamp</span>プラグインを使います。</p>
 </dd>
 <dt class="en">paginate</dt>
 <dd>
-<p><span class="en">previous/next</span>�����N�Ɖ{���\�ȋL���̃��X�g���g���ăy�[�W�̃i�r�Q�[�V�������s���܂��B</p>
+<p><span class="en">previous/next</span>リンクと閲覧可能な記事のリストを使ってページのナビゲーションを行います。</p>
 </dd>
 <dt class="en">paypalform</dt>
 <dd>
-<p><span class="en">This plugin builds a PayPal</span>�̕\�����t���[�o�[�Ɋ܂܂�Ă���ꍇ�͂�����쐬���܂��B�S�ẴE�F�u���O�A�܂��̓Z�N�V���������ɍ쐬���邱�Ƃ��ł��܂��i�����̎��̓t�H�[���ϐ��̓u�����N�ɂȂ�܂��j�B</p>
+<p><span class="en">This plugin builds a PayPal</span>の表示がフレーバーに含まれている場合はそれを作成します。全てのウェブログ、またはセクションだけに作成することができます（無効の時はフォーム変数はブランクになります）。</p>
 </dd>
 <dt class="en">plain_text</dt>
 <dd>
@@ -239,145 +239,145 @@ stripped. </p>
 </dd>
 <dt class="en">postheadprefoot</dt>
 <dd>
-<p>����̃J�e�S���p�X/�f�B���N�g���Ɍ�������<span class="en">posthead.flavour</span>�i����̃t���[�o�[�ɓK�p�\�j�̃R���e���c��<span class="en">posthead</span>�i��ʓI�ɁA�t���[�o�[�ɂ͊֌W����)�t�@�C����<span class="en">head.flavour</span>�ɑ}�����܂��B���l�ɓ���̃J�e�S���p�X/�f�B���N�g���Ɍ�������<span class="en">prefoot.flavour</span>�i����̃t���[�o�[�ɓK�p�\)�̃R���e���c��<span class="en">prefoot</span>�t�@�C���i��ʂɃt���[�o�[�Ɋ֌W����)�t�@�C����<span class="en">foot.flavour</span>�ɑ}�����܂��B</p>
+<p>特定のカテゴリパス/ディレクトリに見つかった<span class="en">posthead.flavour</span>（特定のフレーバーに適用可能）のコンテンツや<span class="en">posthead</span>（一般的に、フレーバーには関係無い)ファイルを<span class="en">head.flavour</span>に挿入します。同様に特定のカテゴリパス/ディレクトリに見つかった<span class="en">prefoot.flavour</span>（特定のフレーバーに適用可能)のコンテンツや<span class="en">prefoot</span>ファイル（一般にフレーバーに関係無い)ファイルを<span class="en">foot.flavour</span>に挿入します。</p>
 </dd>
 <dt class="en">prettycategory</dt>
 <dd>
-<p>�ǂ݂₷�������P���邽�߂ɃJ�e�S�����ɋ󔒂�ǉ����܂��B<span class="en">$prettycategory::category</span>��񋟂��܂��B</p>
+<p>読みやすさを改善するためにカテゴリ名に空白を追加します。<span class="en">$prettycategory::category</span>を提供します。</p>
 </dd>
 <dt class="en">preview</dt>
 <dd>
-<p>���҂��L�������J����O�Ƀv���r���[�ł���悤�ɂ��܂��B</p>
+<p>著者が記事を公開する前にプレビューできるようにします。</p>
 </dd>
 <dt class="en">quotes</dt>
 <dd>
-<p>���̃v���O�C����'<span class="en">quote of the day</span>'�i�{���̈��p��)�X�^�C���̘b����Ǘ����܂��B�K�v�ł���Βʏ�̃E�F�u���O�̃��X�g�Ɉ��p�����܂߂邱�Ƃ��ł��܂��B�ł��ŋ߂̈��p���̓O���[�o���ϐ��Ŏw�肵�܂��B</p>
+<p>このプラグインは'<span class="en">quote of the day</span>'（本日の引用文)スタイルの話題を管理します。必要であれば通常のウェブログのリストに引用文を含めることができます。最も最近の引用文はグローバル変数で指定します。</p>
 </dd>
 <dt class="en">randomtext</dt>
 <dd>
-<p>�t���[�o�[�e���v���[�g�Ŏg�����Ƃɂ��A�f�B���N�g�����烉���_���Ƀt�@�C�������o���ĕ\�����܂��B</p>
+<p>フレーバーテンプレートで使うことにより、ディレクトリからランダムにファイルを取り出して表示します。</p>
 </dd>
 <dt class="en">readme</dt>
 <dd>
-<p>����̃J�e�S��/�f�B���N�g���Ɍ�������<span class="en">readme</span>�t�@�C�����R���e���c�ɒǉ����܂��B</p>
+<p>特定のカテゴリ/ディレクトリに見つかった<span class="en">readme</span>ファイルをコンテンツに追加します。</p>
 </dd>
 <dt class="en">recent_entries</dt>
 <dd>
-<p>�t���[�o�[�e���v���[�g�ɍŋ߂̋L���̃��X�g�����܂��B</p>
+<p>フレーバーテンプレートに最近の記事のリストを作ります。</p>
 </dd>
 <dt class="en">recentwritebacks</dt>
 <dd>
-<p>�ŋߒǉ����ꂽ�L���ɊȒP�Ɉړ����鎖���ł���悤�ɂ���V�����v���O�C���ł��B�w�肵�����ȓ��ɏ����ꂽ�ԐM���������̘b��ɑ΂��Č������s�������ł��܂��B</p>
+<p>最近追加された記事に簡単に移動する事ができるようにする新しいプラグインです。指定した日以内に書かれた返信を持つそれらの話題に対して検索を行う事ができます。</p>
 </dd>
 <dt class="en">reverse</dt>
 <dd>
-<p>�A�[�J�C�u�y�[�W�ŋL���̏��Ԃ��t�ɂ��܂��B���̂��߃C���f�b�N�X�ƃJ�e�S���͓��t�ŋt�ɂȂ�A�A�[�J�C�u�͓��t���ɂȂ�܂��B</p>
+<p>アーカイブページで記事の順番を逆にします。そのためインデックスとカテゴリは日付で逆になり、アーカイブは日付順になります。</p>
 </dd>
 <dt class="en">sameday</dt>
 <dd>
-<p>�e���v���[�g��<span class="en">$sameday::sameday</span>���g�p���ē������t�̋L���Ƀ����N���܂��B�N�͈�ԐV�������̂��Ώۂł��B</p>
+<p>テンプレートで<span class="en">$sameday::sameday</span>を使用して同じ日付の記事にリンクします。年は一番新しいものが対象です。</p>
 </dd>
 <dt class="en">seemore</dt>
 <dd>
-<p>�e�L���̎w��ꏊ�܂ł�\�����A�c���&quot;<span class="en">See More</span>&quot;�Ń����N���܂��B</p>
+<p>各記事の指定場所までを表示し、残りは&quot;<span class="en">See More</span>&quot;でリンクします。</p>
 </dd>
 <dt class="en">sideblog</dt>
 <dd>
-<p><span class="en">head/foot</span>�t�@�C���Ŏg����ϐ��ɂ܂������̂ł��Ă��Ȃ��E�F�u���O�i�R�����g�̖��������N�A�ȒP�Ȍx��A��������Ă��Ȃ��v�l�j���܂�<span class="en">sideblog</span>�t�@�C������ŏ��̍s��ǂݍ��݂܂��B�i�����A���͎��̂��Ă��鎖��c�����Ă��܂���B�������A�g���Ȃ���������Ȃ��ƃR�����g�Ƃ��ē��e�����C�����܂��j�B</p>
+<p><span class="en">head/foot</span>ファイルで使える変数にまだ準備のできていないウェブログ（コメントの無いリンク、簡単な警句、整理されていない思考）を含んだ<span class="en">sideblog</span>ファイルから最初の行を読み込みます。（正直、私は私のしている事を把握していません。しかし、使えないかもしれないとコメントとして投稿した気もします）。</p>
 </dd>
 <dt class="en">sizer</dt>
 <dd>
-<p>�E�F�u���O�y�[�W�̒����𐧌�������@��񋟂��܂��B���̒����ɒB����L���̐��ɂ͊֌W�L��܂���B</p>
+<p>ウェブログページの長さを制限する方法を提供します。その長さに達する記事の数には関係有りません。</p>
 </dd>
 <dt class="en">storytitle</dt>
 <dd>
-<p>�y�[�W�^�C�g���ɘb��̃^�C�g�����g�����Ƃ��ł��܂��B���̃y�[�W�̘b��݂̂œ��삵�܂��B</p>
+<p>ページタイトルに話題のタイトルを使うことができます。そのページの話題のみで動作します。</p>
 </dd>
 <dt class="en">text_template</dt>
 <dd>
-<p>�e���v���[�g�G���W���̐؂�ւ����s�������ł��܂��B (<span class="en">Text::Template</span>) </p>
+<p>テンプレートエンジンの切り替えを行う事ができます。 (<span class="en">Text::Template</span>) </p>
 </dd>
 <dt class="en">visitors</dt>
 <dd>
-<p>���݁A�ǂꂾ���̐l���T�C�g�ɖK��Ă��邩���v�Z���A����<span class="en">login</span>�v���O�C�����C���X�g�[�����Ă���Ή��l�����O�C�����Ă��邩���v�Z���܂��B�l�X���������Ă��鎞�Ԃ�ݒ�ł��܂��B</p>
+<p>現在、どれだけの人がサイトに訪れているかを計算し、もし<span class="en">login</span>プラグインをインストールしてあれば何人がログインしているかを計算します。人々が活動している時間を設定できます。</p>
 </dd>
 <dt class="en">worldpop</dt>
 <dd>
-<p>���E�l�����v���f���[�X���܂��B</p>
+<p>世界人口をプロデュースします。</p>
 </dd>
 <dt class="en">writeback_sort</dt>
 <dd>
-<p>�b�����t�����łȂ��ԐM�̓��t�ŕ��בւ����܂��B�l�X���R�����g�����肵���Ƃ��ɃE�F�u���O�̃g�b�v�ɘb��������グ�܂��B</p>
+<p>話題を日付だけでなく返信の日付で並べ替えします。人々がコメントしたりしたときにウェブログのトップに話題を持ち上げます。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/display/graphics</h2><dl>
 <dt class="en">PostGraph</dt>
 <dd>
-<p>��̈قȂ�t�H�[�}�b�g�i���<span class="en">MT</span>��&quot;<span class="en">blogtimes</span>&quot;�v���O�C���Ɠ��l�j�ŋL�������������̎��Ԃ��O���t�ŕ\�����܂��B</p>
+<p>二つの異なるフォーマット（一つは<span class="en">MT</span>の&quot;<span class="en">blogtimes</span>&quot;プラグインと同様）で記事を書いた日の時間をグラフで表示します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/edit</h2><dl>
 <dt class="en">wikieditish</dt>
 <dd>
-<p><span class="en">Blosxom</span>�̃E�F�u���O��<span class="en">wiki</span>�̂悤�Ƀu���E�U�ŕҏW���܂��B<span class="en">wikiwordish</span>�A<span class="en">tiki</span>�A<span class="en">textile</span>�v���O�C���ŗǍD�ɓ��삵�܂��B�@�\�F�p�X���[�h�ی�A<span class="en">ip</span>�x�[�X�̕ی�A�Ō�ɏC��������/���Ԃ̕ێ�--�������S�đI���\�ł�[**���͎����i�K�ł�**]</p>
+<p><span class="en">Blosxom</span>のウェブログを<span class="en">wiki</span>のようにブラウザで編集します。<span class="en">wikiwordish</span>、<span class="en">tiki</span>、<span class="en">textile</span>プラグインで良好に動作します。機能：パスワード保護、<span class="en">ip</span>ベースの保護、最後に修正した日/時間の保持--もちろん全て選択可能です[**今は実験段階です**]</p>
 </dd>
 </dl>
 <h2 class="en"> /plugins/files</h2><dl>
 <dt class="en">cvsignore</dt>
 <dd>
-<p><span class="en">cvs</span>���s���̂ƉZ��ɓ���̃t�@�C���ƃf�B���N�g���𖳎����� <span class="en">.cvsignore</span>�t�@�C���𗘗p�\�ɂ��܂��B</p>
+<p><span class="en">cvs</span>が行うのと瓜二つに特定のファイルとディレクトリを無視する <span class="en">.cvsignore</span>ファイルを利用可能にします。</p>
 </dd>
 <dt class="en">exclude</dt>
 <dd>
-<p>���̃v���O�C�����g���ƁA����̋L����f�B���N�g����\�����Ȃ��悤�ɂ��邱�Ƃ��ł��܂��B</p>
+<p>このプラグインを使うと、特定の記事やディレクトリを表示しないようにすることができます。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/filtering</h2><dl>
 <dt class="en">xmlrpcfilter</dt>
 <dd>
-<p><span class="en">XML=RPC</span>�t�B���^<span class="en">API</span>��ʂ��ăE�F�u���O�R���e���c�Ƀt�B���^�������܂��B</p>
+<p><span class="en">XML=RPC</span>フィルタ<span class="en">API</span>を通してウェブログコンテンツにフィルタをかけます。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/general</h2><dl>
 <dt class="en">config</dt>
 <dd>
-<p>�f�B���N�g�����ƁA�t���[�o�[���ƁA�t���[�o�[���Ƃ̃f�B���N�g�����Ƃ�<span class="en">Blosxom</span>�̃C�����C���̊��ݒ���㏑�����܂��i�����I�Ȃ��̂ł��I�j�B�ڍׂ͂����������������B</p>
+<p>ディレクトリごと、フレーバーごと、フレーバーごとのディレクトリごとに<span class="en">Blosxom</span>のインラインの環境設定を上書きします（実験的なものです！）。詳細はここをご覧下さい。</p>
 </dd>
 <dt class="en">crop_path</dt>
 <dd>
-<p><span class="en">Blosxom</span>�̃p�X�ϐ����Ō�� <span class="en">n</span> �����ɏk�߂܂��B���̃v���O�C���o�^�y�[�W�̂悤�Ƀp�X�ŕ��בւ��������̃J�e�S����\������y�[�W�ŕ֗��ł��B</p>
+<p><span class="en">Blosxom</span>のパス変数を最後の <span class="en">n</span> 部分に縮めます。このプラグイン登録ページのようにパスで並べ替えた複数のカテゴリを表示するページで便利です。</p>
 </dd>
 <dt class="en">flavourdir</dt>
 <dd>
-<p>�t���[�o�[���E�F�u���O�Ɠ����ꏊ�ɒu���̂ł͂Ȃ��A����Ƃ͈قȂ�t���[�o�[�f�B���N�g���ɒu����悤�ɂ��܂��B</p>
+<p>フレーバーをウェブログと同じ場所に置くのではなく、それとは異なるフレーバーディレクトリに置けるようにします。</p>
 </dd>
 <dt class="en">functions</dt>
 <dd>
-<p>�b��ɑ΂��ĔC�ӂ̊֐��������܂��B�ȒP�Ɋg���ł��܂��B</p>
+<p>話題に対して任意の関数を書きます。簡単に拡張できます。</p>
 </dd>
 <dt class="en">logger</dt>
 <dd>
-<p>���O�t�@�C����<span class="en">CGI</span>�ϐ��i���[�U�G�[�W�F���g�A���t�@���Ȃǁj��ۑ����܂��B��̋�؂蕶���łǂ̕ϐ���ǐՂ���̂��ݒ肪�ł��܂��B�o�O���|�[�g�⌚�ݓI�Ȃ��ӌ������}���܂�--����<span class="en">Perl</span>���S�҂ł��B</p>
+<p>ログファイルに<span class="en">CGI</span>変数（ユーザエージェント、リファラなど）を保存します。列の区切り文字でどの変数を追跡するのか設定ができます。バグレポートや建設的なご意見を歓迎します--私は<span class="en">Perl</span>初心者です。</p>
 </dd>
 <dt class="en">multiblosxom</dt>
 <dd>
-<p>���s����<span class="en">Blosxom</span>�̖��O�Ɋ�Â��O�����t�@�C����ǂݏグ�܂��B<span class="en">Unix</span>�ŃV���{���b�N�����N���g���ƕ֗��ł��B</p>
+<p>実行時に<span class="en">Blosxom</span>の名前に基づく外部環境ファイルを読み上げます。<span class="en">Unix</span>でシンボリックリンクを使うと便利です。</p>
 </dd>
 <dt class="en">pluginfo</dt>
 <dd>
-<p>�t���[�o�[�e���v���[�g�Ŏg���錻�ݎ��s���Ă���v���O�C���Ɋւ�������쐬���܂��B</p>
+<p>フレーバーテンプレートで使える現在実行しているプラグインに関する情報を作成します。</p>
 </dd>
 <dt class="en">publish</dt>
 <dd>
-<p>�y�[�W��ێ�����b���������l������'<span class="en">expires</span>'���^�^�O��񋟂��܂��B���v���O�C���̎��s��A�y�[�W�̓��t���b�V������Ȃ��Ă͂Ȃ�Ȃ��̂Ńv���L�V�T�[�o�̃L���b�V������y�[�W���񋟂���܂���B���ƂŃu���E�U�̃y�[�W���X�V���Ȃ��Ă��A����I�ɒ����Ƀy�[�W���X�V�ł��܂��B</p>
+<p>ページを保持する秒数を示す値を持つ'<span class="en">expires</span>'メタタグを提供します。こプラグインの実行後、ページはリフレッシュされなくてはならないのでプロキシサーバのキャッシュからページが提供されません。手作業でブラウザのページを更新しなくても、定期的に直ぐにページを更新できます。</p>
 </dd>
 <dt class="en">strip_unix_comments</dt>
 <dd>
-<p><span class="en">#</span>�Ŏn�܂�s��S�č폜���܂��B</p>
+<p><span class="en">#</span>で始まる行を全て削除します。</p>
 </dd>
 <dt class="en">subflavour</dt>
 <dd>
-<p><span class="en">Rael</span>��<span class="en">flavourdir</span>�v���O�C���Ɋ�Â������ɒP���ȃv���O�C���ł��B�W���Ŋe�b���̘b�̉�ɕԐM�p�̃T�u�t���[�o�[�������I�ɕ\�����܂��B 
+<p><span class="en">Rael</span>の<span class="en">flavourdir</span>プラグインに基づいた非常に単純なプラグインです。標準で各話題上の話の塊に返信用のサブフレーバーを自動的に表示します。 
 <span class="en">What this means is that it looks for a file called story.htmlwriteback in flavour_dir 
 to use as the template for the story portion of this page if the current flavour 
 is html and if an individual story has been requested. It also has the added bonus 
@@ -390,25 +390,25 @@ about it.</span> </p>
 </dd>
 <dt class="en">twikirender</dt>
 <dd>
-<p>�L����\�����邽�߂Ƀ��[�J����TWiki�𗘗p���܂��B</p>
+<p>記事を表示するためにローカルのTWikiを利用します。</p>
 </dd>
 <dt class="en">urltranslate</dt>
 <dd>
-<p>�Q�ƃe�[�u����URL��ϊ����A�g���l���⃊�_�C���N�g��ʂ��ăA�N�Z�X���ꂽ�o�[�`�����z�X�g�ɑ΂���<span class="en">URL</span>�ɃN���C�A���g�̃|�[�g�ԍ���ǉ����邱�Ƃ��ł��܂��B</p>
+<p>参照テーブルでURLを変換し、トンネルやリダイレクトを通してアクセスされたバーチャルホストに対して<span class="en">URL</span>にクライアントのポート番号を追加することができます。</p>
 </dd>
 <dt class="en">vhost</dt>
 <dd>
-<p>�X��URL���g�����ƂȂ������̃E�F�u���O���쐬���邽�߂ɈقȂ�<span class="en">datadir</span>�����قȂ�<span class="en">vhosts</span>���\�ɂ��܂��B</p>
+<p>醜いURLを使うことなく複数のウェブログを作成するために異なる<span class="en">datadir</span>を持つ異なる<span class="en">vhosts</span>を可能にします。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/headers</h2><dl>
 <dt class="en">cookies</dt>
 <dd>
-<p>���̃v���O�C������g�����Ƃ̂ł����{�I�ȃN�b�L�[�@�\��񋟂��܂��B</p>
+<p>他のプラグインから使うことのできる基本的なクッキー機能を提供します。</p>
 </dd>
 <dt class="en">lastmodified</dt>
 <dd>
-<p>'<span class="en">last-modified</span>'�w�b�_���E�F�u���O�ɒǉ����܂��B <span class="en">This should help enable smarter 
+<p>'<span class="en">last-modified</span>'ヘッダをウェブログに追加します。 <span class="en">This should help enable smarter 
 feed-readers to not pull your blog every time they check (I'm getting spotty behavior 
 from Apache, it may take detecting HEAD requests from inside blosxom).</span> </p>
 </dd>
@@ -424,11 +424,11 @@ user-specific data directory</p>
 <h2 class="en">/plugins/images</h2><dl>
 <dt class="en">gallery</dt>
 <dd>
-<p>�J�X�^���t���[�o�[���g���i�C�X�ȃM�������[�y�[�W�𐶐����������̃M�������[�v���O�C���B</p>
+<p>カスタムフレーバーを使うナイスなギャラリーページを生成するもう一つのギャラリープラグイン。</p>
 </dd>
 <dt class="en">galleryref</dt>
 <dd>
-<p>�M�������[�ɉ摜�^�O��}�����܂��B</p>
+<p>ギャラリーに画像タグを挿入します。</p>
 </dd>
 <dt class="en">iconset</dt>
 <dd>
@@ -437,35 +437,35 @@ basis, though it can also be used on it's own. </p>
 </dd>
 <dt class="en">imagegallery</dt>
 <dd>
-<p>��A�̉摜�ƃT���l�[�����ȒP�ɃT�C�g�ɒǉ��ł���悤�ɂ��܂��B�L���A�摜�̃t�H���_�A�T���l�[���̃t�H���_�A�ǉ��̃R�����g�̃t�H���_���쐬����΂��ƃv���O�C�����������܂��B</p>
+<p>一連の画像とサムネールを簡単にサイトに追加できるようにします。記事、画像のフォルダ、サムネールのフォルダ、追加のコメントのフォルダを作成すればあとプラグインが処理します。</p>
 </dd>
 <dt class="en">imagesizer</dt>
 <dd>
-<p>�摜�ɕ��ƍ����̃^�O��ǉ����܂��B</p>
+<p>画像に幅と高さのタグを追加します。</p>
 </dd>
 <dt class="en">meta_image</dt>
 <dd>
-<p>�L������&quot;<span class="en">meta-imgurl</span>&quot;��&quot;<span class="en">meta-imgalt</span>&quot;�^�O�����o���A�L���ŏq�ׂ�ꂽ�摜��K�؂ɕ\������悤��<span class="en">HTML</span>�𐶐����܂��B</p>
+<p>記事から&quot;<span class="en">meta-imgurl</span>&quot;と&quot;<span class="en">meta-imgalt</span>&quot;タグを取り出し、記事で述べられた画像を適切に表示するような<span class="en">HTML</span>を生成します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/include</h2><dl>
 <dt class="en">file</dt>
 <dd>
-<p><span class="en">Blosxom</span>�t���[�o�[�e���v���[�g���Ŏg����悤�ɕϐ��Ƀt�@�C���̒��g��ǂݍ��݂܂��B</p>
+<p><span class="en">Blosxom</span>フレーバーテンプレート内で使えるように変数にファイルの中身を読み込みます。</p>
 </dd>
 <dt class="en">include</dt>
 <dd>
-<p>�t�@�C����R�}���h�̌��ʂ��܂߂�悤�ɂ��܂��i�Z�L�����e�B�̖�肪���邩���m��܂���j�B</p>
+<p>ファイルやコマンドの結果を含めるようにします（セキュリティの問題があるかも知れません）。</p>
 </dd>
 </dl>
 <h2 class="en"> /plugins/indexing</h2><dl>
 <dt class="en">entries_cache</dt>
 <dd>
-<p><span class="en">entries_index</span>�̔h���i�ŁA��������̋L��������<span class="en">Blosxom</span>�T�C�g�ŏ��������������邽�߂ɘb��̃C���f�b�N�X���L���b�V�����܂��B<span class="en">entries_index</span>�Ɠ��l�Ƀt�@�C���̏C�����Ԃ��L���b�V�����܂��B</p>
+<p><span class="en">entries_index</span>の派生品で、たくさんの記事がある<span class="en">Blosxom</span>サイトで処理を高速化するために話題のインデックスをキャッシュします。<span class="en">entries_index</span>と同様にファイルの修正時間もキャッシュします。</p>
 </dd>
 <dt class="en">entries_index</dt>
 <dd>
-<p>�E�F�u���O�̃I���W�i���̍쐬�^�C���X�^���v��ێ����ăI���W�i���̍쐬���Ԃ�ύX���邱�ƂȂ��L���̕ҏW���\�ɂ��܂��B</p>
+<p>ウェブログのオリジナルの作成タイムスタンプを保持してオリジナルの作成時間を変更することなく記事の編集を可能にします。</p>
 </dd>
 <dt class="en">entries_index_tagged</dt>
 <dd>
@@ -478,15 +478,15 @@ plugin. This is useful if you upload your stories to a remote webserver via FTP.
 <h2 class="en">/plugins/input</h2><dl>
 <dt class="en">comments</dt>
 <dd>
-<p>�ԐM�Ɋ�Â��i�ԐM��ϊ����鎖���ł��܂����A�ԐM�ւ̃R�����g����ł͂���܂���j�A�R�����g�ɃX���b�h�ƃ^�C���X�^���v��ǉ����܂��B�܂��A�^�C�g����K�؂ɖ��߂܂��B�����Ƌ@�\��ǉ��������̂ł����A�t�B�[�h�o�b�N�L�������܂��I</p>
+<p>返信に基づき（返信を変換する事ができますが、返信へのコメントからではありません）、コメントにスレッドとタイムスタンプを追加します。また、タイトルを適切に埋めます。もっと機能を追加したいのですが、フィードバック有難う御座います！</p>
 </dd>
 <dt class="en">dbcomments</dt>
 <dd>
-<p><span class="en">Blosxom</span>���̂��g���ĕ��s�����R�����g�̃E�F�u���O���쐬���邱�Ƃɂ���ăE�F�u���O�ɃR�����g���쐬���܂��B</p>
+<p><span class="en">Blosxom</span>自体を使って並行したコメントのウェブログを作成することによってウェブログにコメントを作成します。</p>
 </dd>
 <dt class="en">emailcomments</dt>
 <dd>
-<p>�{���҂Ƀ��[���ŃR�����g�𑗂��悤�ɂ��܂��B </p>
+<p>閲覧者にメールでコメントを送れるようにします。 </p>
 </dd>
 <dt class="en">karma</dt>
 <dd>
@@ -513,7 +513,7 @@ could be, &quot;0 comments (why not post the first comment?)&quot; or for 1 writ
 </dd>
 <dt class="en">seewritebacks</dt>
 <dd>
-<p>�����̃t���[�o�[�ŕԐM���ȒP�ɉ\�ɂ��܂��B</p>
+<p>複数のフレーバーで返信を簡単に可能にします。</p>
 </dd>
 <dt class="en">submission</dt>
 <dd>
@@ -530,27 +530,27 @@ Puts submissions into pending status, which you can view, too. </p>
 </dd>
 <dt class="en">writeback</dt>
 <dd>
-<p>�E�F�u���O��<span class="en">WriteBacks</span>��񋟂��܂��B�R�����g��<span class="en">TrackBack</span>�̂��킹�Z�ł��B</p>
+<p>ウェブログに<span class="en">WriteBacks</span>を提供します。コメントと<span class="en">TrackBack</span>のあわせ技です。</p>
 </dd>
 <dt class="en">writeback-notify</dt>
 <dd>
-<p>�I���W�i����<span class="en">writeback</span>�v���O�C����6�s���n�b�N���ĐV�����R�����g�����[���Œʒm�ł���悤�ɂ������̂ł��B���̃n�b�N�̓I���W�i���̃v���O�C���̃p�t�H�[�}���X�ɉe����^���܂���B</p>
+<p>オリジナルの<span class="en">writeback</span>プラグインの6行をハックして新しいコメントをメールで通知できるようにしたものです。このハックはオリジナルのプラグインのパフォーマンスに影響を与えません。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/interpolate</h2><dl>
 <dt class="en">interpolate_conditional</dt>
 <dd>
-<p>�e���v���[�g�Ƀe�L�X�g��e���v���[�g�ϐ��̒l�������t���œǂݍ��݂܂��B</p>
+<p>テンプレートにテキストやテンプレート変数の値を条件付きで読み込みます。</p>
 </dd>
 <dt class="en">interpolate_fancy</dt>
 <dd>
-<p><span class="en">Blosxom</span>�������ƊȒP�Ɏg���āA��������萧������悤�ɁA�W����<span class="en">interpolate()</span>�T�u���[�`�����I�[�o�[���C�h���܂��B���݂̃R���e���c��œ��삵�Č��ʂ�Ԃ����ǂ����ȂǁA�y�[�W�̂ǂ̂悤�ȏꏊ�ł��A�N�V�����i�v���O�C���T�u���[�`�����Ăяo���Ȃǁj�����s���܂��B�e���v���[�g�̃e�L�X�g��e���v���[�g�ϐ��̒l�������t�A�܂��͏����Ȃ��œǂݍ��݂܂��B�����ɂ͎��̂��̂��܂݂܂��F��`���ꂽ�A����`�A*�ɓ������A*�ɓ������Ȃ��A*��菬�����A*���傫���A*�Ɏ��Ă���A*�Ɏ��Ă��Ȃ��i<span class="en">regex</span>�j�B</p>
+<p><span class="en">Blosxom</span>をもっと簡単に使えて、しかしより制限するように、標準の<span class="en">interpolate()</span>サブルーチンをオーバーライドします。現在のコンテンツ上で動作して結果を返すかどうかなど、ページのどのような場所でもアクション（プラグインサブルーチンを呼び出すなど）を実行します。テンプレートのテキストやテンプレート変数の値を条件付、または条件なしで読み込みます。制限には次のものを含みます：定義された、未定義、*に等しい、*に等しくない、*より小さい、*より大きい、*に似ている、*に似ていない（<span class="en">regex</span>）。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/link</h2><dl>
 <dt class="en">absolute</dt>
 <dd>
-<p>�摜�^�O�̑��΃p�X��u�������A���S�p�X�Ńn�C�p�[�����N���쐬���܂��B</p>
+<p>画像タグの相対パスを置き換え、完全パスでハイパーリンクを作成します。</p>
 </dd>
 <dt class="en">autolink</dt>
 <dd>
@@ -559,20 +559,20 @@ of your posts </p>
 </dd>
 <dt class="en">citysearchtag</dt>
 <dd>
-<p><span class="en">&lt;citysearch&gt;keyword&lt;citysearch&gt;</span>��<span class="en">citysearch</span>�̌��������N�ɕϊ����܂��B���ӁF 
-<span class="en">citysearch.com</span> �ł͖�����<span class="en">citysearch.com.au</span>�ł��B</p>
+<p><span class="en">&lt;citysearch&gt;keyword&lt;citysearch&gt;</span>を<span class="en">citysearch</span>の検索リンクに変換します。注意： 
+<span class="en">citysearch.com</span> では無くて<span class="en">citysearch.com.au</span>です。</p>
 </dd>
 <dt class="en">debpackagetag</dt>
 <dd>
-<p><span class="en">&lt;debpackage&gt;blosxom&lt;debpackage&gt;</span>��<span class="en">debian</span>�p�b�P�[�W�y�[�W�ւ̃����N�ɕϊ����܂��B</p>
+<p><span class="en">&lt;debpackage&gt;blosxom&lt;debpackage&gt;</span>を<span class="en">debian</span>パッケージページへのリンクに変換します。</p>
 </dd>
 <dt class="en">favorites</dt>
 <dd>
-<p><span class="en">IE</span>�̂��C�ɓ��肩�烊���N�𐶐����܂��B</p>
+<p><span class="en">IE</span>のお気に入りからリンクを生成します。</p>
 </dd>
 <dt class="en">lcase</dt>
 <dd>
-<p><span class="en">URL</span>���������ɕϊ����܂��B</p>
+<p><span class="en">URL</span>を小文字に変換します。</p>
 </dd>
 <dt class="en">macrolinks</dt>
 <dd>
@@ -604,18 +604,18 @@ first Amazon product link (if any) mentioned in a entry </p>
 <h2 class="en">/plugins/link/google</h2><dl>
 <dt class="en">google</dt>
 <dd>
-<p>�L�[���[�h��<span class="en">Google</span>�̌������ł���悤�ɂ��܂��B</p>
+<p>キーワードで<span class="en">Google</span>の検索ができるようにします。</p>
 </dd>
 <dt class="en">googletag</dt>
 <dd>
-<p><span class="en">&lt;google&gt;keyword&lt;google&gt;</span>��<span class="en">Google</span>�̌��������N�ɕϊ����܂��B</p>
+<p><span class="en">&lt;google&gt;keyword&lt;google&gt;</span>を<span class="en">Google</span>の検索リンクに変換します。</p>
 </dd>
 </dl>
 <h2 class="en"> /plugins/logs</h2><dl>
 <dt class="en">referer</dt>
 <dd>
-<p>�M���̂̃E�F�u���O�ւ̍ł��ŋ߂̃��t�@����<span class="en">$referer::recent</span>�̒l���Z�b�g���܂��B�Q�Ƃ��ꂽ�񐔂ɂ�郊�X�g���g���̂ŁA�����h���C���ł��قȂ郊�t�@���̃q�b�g���g���܂��B�M���̃E�F�u���O���u����Ă���h���C������̃q�b�g�͌��o���Ȃ��̂Ń����[�h�̓J�E���g����܂���B�M���̃T�C�g�ɐڑ����Ă���E�F�u���O�ɑ΂��ē���̖��O��t���邱�Ƃ��ł���̂ŁA���[�U��<span class="en">bob_blog.com</span>�̕ς���<span class="en">Bob's 
-Blog</span>�ƌ��������N�����邱�ƂɂȂ�܂��B</p>
+<p>貴方ののウェブログへの最も最近のリファラで<span class="en">$referer::recent</span>の値をセットします。参照された回数によるリストを使うので、同じドメインでも異なるリファラのヒットも使えます。貴方のウェブログが置かれているドメインからのヒットは検出しないのでリロードはカウントされません。貴方のサイトに接続しているウェブログに対して特定の名前を付けることができるので、ユーザは<span class="en">bob_blog.com</span>の変わりに<span class="en">Bob's 
+Blog</span>と言うリンクを見ることになります。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/macros</h2><dl>
@@ -643,17 +643,17 @@ of said rating for use in a flavour template. </p>
 <h2 class="en">/plugins/output</h2><dl>
 <dt class="en">autotrack</dt>
 <dd>
-<p>�����A�������̃g���b�N�o�b�N�s���O�B</p>
+<p>自動、半自動のトラックバックピング。</p>
 </dd>
 <dt class="en">ping_weblogs_com</dt>
 <dd>
-<p>�M���̃E�F�u���O���X�V���ꂽ����<span class="en">weblogs.com</span>�ɒʒm���܂��B</p>
+<p>貴方のウェブログが更新された事を<span class="en">weblogs.com</span>に通知します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/programming</h2><dl>
 <dt class="en">inline_python</dt>
 <dd>
-<p><span class="en">Blosxom</span>�v���O�C����<span class="en">Python</span>�ŏ��������ƍl���Ă���l�̂��߂̏����ȃv���O�C���ł��B<span class="en"> [ Not for the 
+<p><span class="en">Blosxom</span>プラグインを<span class="en">Python</span>で書きたいと考えている人のための小さなプラグインです。<span class="en"> [ Not for the 
 faint of heart, mind you ;-]</span> </p>
 </dd>
 <dt class="en">modules</dt>
@@ -664,57 +664,57 @@ faint of heart, mind you ;-]</span> </p>
 <h2 class="en">/plugins/search</h2><dl>
 <dt class="en">find</dt>
 <dd>
-<p>�E�F�u���O�T�C�g�ɑ΂��錟����񋟂��܂��B</p>
+<p>ウェブログサイトに対する検索を提供します。</p>
 </dd>
 <dt class="en">google_sitesearch</dt>
 <dd>
-<p>�M���̃E�F�u���O�ɑ΂���<span class="en">Google Free Site Search</span>��񋟂��܂��B</p>
+<p>貴方のウェブログに対して<span class="en">Google Free Site Search</span>を提供します。</p>
 </dd>
 <dt class="en">lucene</dt>
 <dd>
-<p><span class="en">Lucene</span>�����̌��ʂŃt�b�N���A�����L�[���[�h�Ɉ�v����b��݂̂�\�����܂��i<span class="en">?q=keywords</span>�Ŏw�肷��)�B </p>
+<p><span class="en">Lucene</span>検索の結果でフックし、検索キーワードに一致する話題のみを表示します（<span class="en">?q=keywords</span>で指定する)。 </p>
 </dd>
 </dl>
 <h2 class="en">/plugins/sort</h2><dl>
 <dt class="en">sort_by_name</dt>
 <dd>
-<p>�t�@�C�����ŋL������בւ��܂��B</p>
+<p>ファイル名で記事を並べ替えます。</p>
 </dd>
 <dt class="en">sort_by_path</dt>
 <dd>
-<p>�W���̓��t���̋t�ł͖����ăp�X�ŋL������בւ��܂��B</p>
+<p>標準の日付順の逆では無くてパスで記事を並べ替えます。</p>
 </dd>
 <dt class="en">zlocaldepth</dt>
 <dd>
-<p>�y�[�W���Ƀy�[�W�̐[����ݒ肷��<span class="en">config</span>�v���O�C�����g����悤�ɂ��܂��B</p>
+<p>ページ毎にページの深さを設定する<span class="en">config</span>プラグインを使えるようにします。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/syndication</h2><dl>
 <dt class="en">klip</dt>
 <dd>
-<p><span class="en">Blosxom</span>�̃t���[�o�[�t�@�C�������o���A�j���[�X�W�F�l���[�^�[�̈��ł���<span class="en">KlipFolio</span>��<span class="en">klip</span>�t�@�C���ɕϊ����܂��B</p>
+<p><span class="en">Blosxom</span>のフレーバーファイルを取り出し、ニュースジェネレーターの一種である<span class="en">KlipFolio</span>の<span class="en">klip</span>ファイルに変換します。</p>
 </dd>
 <dt class="en">necho-flavour</dt>
 <dd>
-<p>���݂�<span class="en">Echo</span>�i�Ⴄ���O�ŌĂ΂ꂽ������܂��j�ƌ����V�����V���W�P�[�g�ɂ�����t���[�o�[�t�@�C����ZIP�Ɋ܂߂Ă���܂��B����͂܂������̂��̂ł��̂ŁA�ŏI�I�Ȃ��̂ł͂Ȃ��ăR���Z�v�g�Ƃ��Ď�舵���ĉ������B</p>
+<p>現在は<span class="en">Echo</span>（違う名前で呼ばれたりもします）と言う新しいシンジケートにおけるフレーバーファイルをZIPに含めてあります。これはまだ早期のものですので、最終的なものではなくてコンセプトとして取り扱って下さい。</p>
 </dd>
 <dt class="en">rss10</dt>
 <dd>
-<p>�Ó���<span class="en">RSS1.0</span>��񋟂��邽�߂ɕK�v�Ȓǉ��̑����̃v���O���~���O��񋟂��܂��B</p>
+<p>妥当な<span class="en">RSS1.0</span>を提供するために必要な追加の多少のプログラミングを提供します。</p>
 </dd>
 </dl>
 <h2 class="en">/plugins/text</h2><dl>
 <dt class="en">amps</dt>
 <dd>
-<p>�L���ɂ���<span class="en">&amp;</span>��<span class="en">&amp;amp;</span>�ɒu�������܂�</p>
+<p>記事にある<span class="en">&amp;</span>を<span class="en">&amp;amp;</span>に置き換えます</p>
 </dd>
 <dt class="en">atx</dt>
 <dd>
-<p><span class="en">Blosxom</span>�̋L����^�ɍ\�������ꂽ�e�L�X�g�t�H�[�}�b�g�ł���<span class="en">atx</span>�ŏ����܂��B</p>
+<p><span class="en">Blosxom</span>の記事を真に構造化されたテキストフォーマットである<span class="en">atx</span>で書きます。</p>
 </dd>
 <dt class="en">autocorrect</dt>
 <dd>
-<p>���̃J�e�S���K�w�Ɉړ������E�F�u���O�G���g���ւ̉\�Ȍ���̈�v��񋟂��܂��B</p>
+<p>他のカテゴリ階層に移動したウェブログエントリへの可能な限りの一致を提供します。</p>
 </dd>
 <dt class="en">coderpants</dt>
 <dd>
@@ -724,27 +724,27 @@ snippits via '@' and code blocks via '@@'. </p>
 </dd>
 <dt class="en">dictionary</dt>
 <dd>
-<p>�e�L�X�g�t�@�C���̃��X�g����P������o���A���̒P��̒�`��������Ă���y�[�W�ւ̃����N�ł����̑S�Ă̒P���u�������܂��B</p>
+<p>テキストファイルのリストから単語を取り出し、その単語の定義が書かれているページへのリンクでそれらの全ての単語を置き換えます。</p>
 </dd>
 <dt class="en">foreshortened</dt>
 <dd>
-<p>�ŏ��̃Z���e���X�̏I���ŏI������E�F�u���O�̖{�����������o�[�W�������쐬���܂��i<span class="en">RSS</span>�ɑ΂��Ęb���Z���������̂��Ӑ}���Ă��܂��j�B</p>
+<p>最初のセンテンスの終わりで終了するウェブログの本文を持ったバージョンを作成します（<span class="en">RSS</span>に対して話題を短くしたものを意図しています）。</p>
 </dd>
 <dt class="en">kwiki</dt>
 <dd>
-<p><span class="en">Blosoxom</span>�E�F�u���O�ɑ΂��鐮�`�c�[���Ƃ���<span class="en">Brian Ingerson</span>�̑f���炵��<span class="en">Kwiki</span>�\�t�g���g���܂��B</p>
+<p><span class="en">Blosoxom</span>ウェブログに対する整形ツールとして<span class="en">Brian Ingerson</span>の素晴らしい<span class="en">Kwiki</span>ソフトを使います。</p>
 </dd>
 <dt class="en">paragraph</dt>
 <dd>
-<p>�e�p���O���t�̍ŏ��̕������J�X�^�}�C�Y���܂��B�T�C�Y�ƐF���g������������摜���g�����Ƃ��ł��܂��B</p>
+<p>各パラグラフの最初の文字をカスタマイズします。サイズと色を使った字下げや画像を使うことができます。</p>
 </dd>
 <dt class="en">random_text</dt>
 <dd>
-<p>���[�U�������e�i���X�ł�����p�t�@�C�����烉���_���Ƀe�L�X�g�𐶐����܂��B</p>
+<p>ユーザがメンテナンスできる引用ファイルからランダムにテキストを生成します。</p>
 </dd>
 <dt class="en">smartypants</dt>
 <dd>
-<p>����̃^�C�|�O���t�B�b�N�ϊ����s���܂� --�X�}�[�g�N�I�[�g�A�X�}�[�g�_�b�V���A�X�}�[�g�ȉ~--</p>
+<p>幾つかのタイポグラフィック変換を行います --スマートクオート、スマートダッシュ、スマート楕円--</p>
 </dd>
 <dt class="en">textile</dt>
 <dd>
@@ -758,13 +758,13 @@ Converts internationalised text from 8-bit codes and LaTeX-style markup. </p>
 </dd>
 <dt class="en">tiki</dt>
 <dd>
-<p><span class="en">HTML</span>�����ŃE�F�u���O�𐮌`���邽�߂�<span class="en">TIm  Appnel</span>��<span class="en">Tiki</span>���W���[���Ńt�b�N���܂��B</p>
+<p><span class="en">HTML</span>無しでウェブログを整形するために<span class="en">TIm  Appnel</span>の<span class="en">Tiki</span>モジュールでフックします。</p>
 </dd>
 <dt class="en">wikiwordish</dt>
 <dd>
-<p><span class="en">Wiki</span>���̋@�\��񋟂��܂��B[<span class="en">[someword]</span>]��߂炦�A�E�F�u���O�̃t�@�C���������v������̂�T���܂��B<span class="en">InterWikiWords</span>�₻�̑��������T�|�[�g���Ă��܂��B�ڍׂ̓C�����C���̃h�L�������g�������������B</p>
+<p><span class="en">Wiki</span>風の機能を提供します。[<span class="en">[someword]</span>]を捕らえ、ウェブログのファイル名から一致するものを探します。<span class="en">InterWikiWords</span>やその他多くをサポートしています。詳細はインラインのドキュメントをご覧下さい。</p>
 </dd>
-</dl><p class="nextLink"><a href="#top">[�y�[�W�̐擪�֖߂�]</a></p></td>
+</dl><p class="nextLink"><a href="#top">[ページの先頭へ戻る]</a></p></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
I wanted to read this page, but it was garbled.
<img width="1331" alt="2017-04-25 4 19 04" src="https://cloud.githubusercontent.com/assets/12012186/25354585/67c4afd0-296e-11e7-8858-788bfb7da198.png">

So I converted it to UTF-8 and read it.
I will too issue a pull request.

Convert command:

```console
$ find . -name '*.html' | LC_ALL=C xargs sed -i '' 's|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">|<!DOCTYPE html>|g'
$ find . -name '*.html' | LC_ALL=C xargs sed -i '' 's|<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">|<meta charset="UTF-8">|g'
$ nkf -w -Lu --overwrite ./*.html
```